### PR TITLE
Add support for Linux in the PostBuildEvent

### DIFF
--- a/CCL_GameScripts/CCL_GameScripts.csproj
+++ b/CCL_GameScripts/CCL_GameScripts.csproj
@@ -23,6 +23,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="setlocal enableextensions&#xD;&#xA;if not exist &quot;$(SolutionDir)$(OutDir)&quot; md &quot;$(SolutionDir)$(OutDir)&quot;&#xD;&#xA;endlocal&#xD;&#xA;xcopy /d /y &quot;$(TargetPath)&quot; &quot;$(SolutionDir)$(OutDir)&quot;" />
+		<Exec Condition="'$(OS)' == 'Windows_NT'" Command="setlocal enableextensions&#xD;&#xA;if not exist &quot;$(SolutionDir)$(OutDir)&quot; md &quot;$(SolutionDir)$(OutDir)&quot;&#xD;&#xA;endlocal&#xD;&#xA;xcopy /d /y &quot;$(TargetPath)&quot; &quot;$(SolutionDir)$(OutDir)&quot;" />
+		<Exec Condition="'$(OS)' != 'Windows_NT'" Command="mkdir -p &quot;$(SolutionDir)$(OutDir)&quot;; cp -pfu &quot;$(TargetPath)&quot; &quot;$(SolutionDir)$(OutDir)&quot;" />
 	</Target>
 </Project>

--- a/DVCustomCarLoader/DVCustomCarLoader.csproj
+++ b/DVCustomCarLoader/DVCustomCarLoader.csproj
@@ -38,6 +38,7 @@
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="setlocal enableextensions&#xD;&#xA;if not exist &quot;$(SolutionDir)$(OutDir)&quot; md &quot;$(SolutionDir)$(OutDir)&quot;&#xD;&#xA;endlocal&#xD;&#xA;xcopy /d /y &quot;$(TargetPath)&quot; &quot;$(SolutionDir)$(OutDir)&quot;" />
+		<Exec Condition="'$(OS)' == 'Windows_NT'" Command="setlocal enableextensions&#xD;&#xA;if not exist &quot;$(SolutionDir)$(OutDir)&quot; md &quot;$(SolutionDir)$(OutDir)&quot;&#xD;&#xA;endlocal&#xD;&#xA;xcopy /d /y &quot;$(TargetPath)&quot; &quot;$(SolutionDir)$(OutDir)&quot;" />
+		<Exec Condition="'$(OS)' != 'Windows_NT'" Command="mkdir -p &quot;$(SolutionDir)$(OutDir)&quot;; cp -pfu &quot;$(TargetPath)&quot; &quot;$(SolutionDir)$(OutDir)&quot;" />
 	</Target>
 </Project>


### PR DESCRIPTION
When building on Linux, the PostBuildEvent's fail due to the Windows commands not existing. This adds an additional Exec that replicates the behavior with GNU coreutils and puts both versions behind an OS condition.