### PR TITLE
Add Passengers cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -543,3 +543,6 @@ $RECYCLE.BIN/
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,visualstudio,csharp
 Directory.Build.targets
+
+# Jetbrains Rider
+.idea

--- a/CCL.Types/BaseTrainCarType.cs
+++ b/CCL.Types/BaseTrainCarType.cs
@@ -123,6 +123,7 @@
         EmptyNovae,
         EmptyTraeg,
         EmptyChemlek,
-        EmptyNeoGamma
+        EmptyNeoGamma,
+        Passengers = 1000
     }
 }


### PR DESCRIPTION
Adds Passenger as cargotype.  
Bug: when setting the cargotype to Passengers, the custom wagon doesn't get the CargoModelController, CargoDamageModel and CargoContent components. Do you have any idea why?

My car with passenger cargo:
![afbeelding](https://github.com/derail-valley-modding/custom-car-loader/assets/18124323/f4f789ce-9006-488a-8eb1-d0025f3357d9)

A different CCL car with different cargo:
![afbeelding](https://github.com/derail-valley-modding/custom-car-loader/assets/18124323/da0b74c5-e99d-4ade-b463-827b61b19032)
