### PR TITLE
Random prefab picker

### DIFF
--- a/CCL.Creator/Editor/RandomPrefabPickerEditor.cs
+++ b/CCL.Creator/Editor/RandomPrefabPickerEditor.cs
@@ -39,8 +39,8 @@ namespace CCL.Creator.Editor
 
             if (_showPrefabs)
             {
-                // Size selector.
-                int length = Mathf.Max(0, EditorGUILayout.IntField("Size", _picker.Prefabs.Length));
+                // Size selector, using delayed field to not lose data accidentally.
+                int length = Mathf.Max(0, EditorGUILayout.DelayedIntField("Size", _picker.Prefabs.Length));
 
                 // Resize array if the length has changed or they're mismatched.
                 if (length != _picker.Prefabs.Length || length != _picker.Weights.Length)
@@ -56,7 +56,7 @@ namespace CCL.Creator.Editor
 
                     _picker.Prefabs[i] = (GameObject)EditorGUILayout.ObjectField(new GUIContent($"Prefab {i}",
                         "The prefab and its relative weight of being selected"), _picker.Prefabs[i], typeof(GameObject), false);
-                    _picker.Weights[i] = EditorGUILayout.FloatField(_picker.Weights[i], GUILayout.MaxWidth(65));
+                    _picker.Weights[i] = Mathf.Max(0, EditorGUILayout.FloatField(_picker.Weights[i], GUILayout.MaxWidth(65)));
 
                     EditorGUILayout.EndHorizontal();
                 }
@@ -90,10 +90,20 @@ namespace CCL.Creator.Editor
                 EditorGUI.indentLevel++;
 
                 float[] percents = _picker.GetPercentagesFromWeights();
+                bool hasZero = false;
 
                 for (int i = 0; i < percents.Length; i++)
                 {
+                    // Rounded to make it easier on the eyes.
                     EditorGUILayout.LabelField($"Prefab {i}", $"{percents[i] * 100.0f:F2}%");
+                    hasZero |= _picker.Weights[i] <= 0;
+                }
+
+                // Warn the user if this is intentional or not.
+                if (hasZero)
+                {
+                    EditorGUILayout.Space();
+                    EditorGUILayout.HelpBox("At least one choice has a weight of 0!", MessageType.Warning);
                 }
 
                 EditorGUI.indentLevel--;

--- a/CCL.Creator/Editor/RandomPrefabPickerEditor.cs
+++ b/CCL.Creator/Editor/RandomPrefabPickerEditor.cs
@@ -1,0 +1,116 @@
+﻿using CCL.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace CCL.Creator.Editor
+{
+    [CanEditMultipleObjects]
+    [CustomEditor(typeof(RandomPrefabPicker))]
+    internal class RandomPrefabPickerEditor : UnityEditor.Editor
+    {
+        private SerializedProperty _chanceX;
+        private SerializedProperty _chanceY;
+        private SerializedProperty _chanceZ;
+
+        private RandomPrefabPicker _picker;
+        private bool _showPrefabs = false;
+        private bool _showChances = false;
+
+        private void OnEnable()
+        {
+            _chanceX = serializedObject.FindProperty("ChanceX");
+            _chanceY = serializedObject.FindProperty("ChanceY");
+            _chanceZ = serializedObject.FindProperty("ChanceZ");
+
+            _picker = (RandomPrefabPicker)serializedObject.targetObject;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            // Foldout with the prefabs and their weights.
+            _showPrefabs = EditorGUILayout.Foldout(_showPrefabs, "Prefabs");
+
+            if (_showPrefabs)
+            {
+                // Size selector.
+                int length = Mathf.Max(0, EditorGUILayout.IntField("Size", _picker.Prefabs.Length));
+
+                // Resize array if the length has changed or they're mismatched.
+                if (length != _picker.Prefabs.Length || length != _picker.Weights.Length)
+                {
+                    _picker.ResizeArrays(length);
+                }
+
+                EditorGUI.indentLevel++;
+
+                for (int i = 0; i < length; i++)
+                {
+                    EditorGUILayout.BeginHorizontal();
+
+                    _picker.Prefabs[i] = (GameObject)EditorGUILayout.ObjectField(new GUIContent($"Prefab {i}",
+                        "The prefab and its relative weight of being selected"), _picker.Prefabs[i], typeof(GameObject), false);
+                    _picker.Weights[i] = EditorGUILayout.FloatField(_picker.Weights[i], GUILayout.MaxWidth(65));
+
+                    EditorGUILayout.EndHorizontal();
+                }
+
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.Space();
+
+            // Sliders for the chances to flip.
+            _chanceX.floatValue = EditorGUILayout.Slider(new GUIContent("Chance to rotate around X",
+                "The chance for the prefab to be rotated 180 degrees around the X axis"),
+                _chanceX.floatValue, 0.0f, 1.0f);
+            _chanceY.floatValue = EditorGUILayout.Slider(new GUIContent("Chance to rotate around Y",
+                "The chance for the prefab to be rotated 180 degrees around the Y axis"),
+                _chanceY.floatValue, 0.0f, 1.0f);
+            _chanceZ.floatValue = EditorGUILayout.Slider(new GUIContent("Chance to rotate around Z",
+                "The chance for the prefab to be rotated 180 degrees around the Z axis"),
+                _chanceZ.floatValue, 0.0f, 1.0f);
+
+            // Apply changes, everything below this is just display.
+            serializedObject.ApplyModifiedProperties();
+
+            EditorGUILayout.Space();
+
+            // Foldout with the weights converted to percentages.
+            _showChances = EditorGUILayout.Foldout(_showChances, "Chances");
+
+            if (_showChances)
+            {
+                EditorGUI.indentLevel++;
+
+                float[] percents = _picker.GetPercentagesFromWeights();
+
+                for (int i = 0; i < percents.Length; i++)
+                {
+                    EditorGUILayout.LabelField($"Prefab {i}", $"{percents[i] * 100.0f:F2}%");
+                }
+
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.Space();
+
+            // Button to instantiate the prefab as if it was ingame, undoable.
+            if (GUILayout.Button("Preview"))
+            {
+                GameObject go = _picker.InstantiateOne();
+
+                if (go)
+                {
+                    Undo.RegisterCreatedObjectUndo(go, "Created preview");
+                }
+            }
+        }
+    }
+}

--- a/CCL.Types/RandomPrefabPicker.cs
+++ b/CCL.Types/RandomPrefabPicker.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace CCL.Types
+{
+    public class RandomPrefabPicker : MonoBehaviour
+    {
+        private static System.Random s_random = new System.Random();
+
+        public GameObject[] Prefabs = new GameObject[0];
+        public float[] Weights = new float[0];
+
+        public float ChanceX = 0.0f;
+        public float ChanceY = 0.0f;
+        public float ChanceZ = 0.0f;
+
+        private void Start()
+        {
+            InstantiateOne();
+        }
+
+        public void ResizeArrays(int newLength)
+        {
+            GameObject[] prefabs = new GameObject[newLength];
+            float[] weights = new float[newLength];
+
+            for (int i = 0; i < newLength; i++)
+            {
+                if (i < Prefabs.Length)
+                {
+                    // Copy the existing values.
+                    prefabs[i] = Prefabs[i];
+                }
+                else
+                {
+                    if (Prefabs.Length > 0)
+                    {
+                        // Copy the last value for any new slots.
+                        prefabs[i] = Prefabs[Prefabs.Length - 1];
+                    }
+                    else
+                    {
+                        // No prefab.
+                        prefabs[i] = null!;
+                    }
+                }
+
+                // Same for the weights.
+                if (i < Weights.Length)
+                {
+                    weights[i] = Weights[i];
+                }
+                else
+                {
+                    if (Weights.Length > 0)
+                    {
+                        weights[i] = Weights[Weights.Length - 1];
+                    }
+                    else
+                    {
+                        weights[i] = 1.0f;
+                    }
+                }
+            }
+
+            Prefabs = prefabs;
+            Weights = weights;
+        }
+
+        public GameObject InstantiateOne()
+        {
+            if (Prefabs.Length <= 0)
+            {
+                Debug.Log("Prefab array is empty.");
+                return null!;
+            }
+
+            if (Prefabs.Length != Weights.Length)
+            {
+                Debug.Log($"Array length mismatch (P:{Prefabs.Length}|W:{Weights.Length})");
+                return null!;
+            }
+
+            int choice = PickOne();
+            GameObject go = Instantiate(Prefabs[choice], transform);
+
+            if (!go)
+            {
+                Debug.LogWarning($"Instanced object is null (index {choice}), check if something is wrong");
+                return null!;
+            }
+
+            var (x, y, z) = GetFlips();
+            go.transform.localRotation *= Quaternion.Euler(x ? 180 : 0, y ? 180 : 0, z ? 180 : 0);
+
+            return go;
+        }
+
+        public int PickOne()
+        {
+            // Result is somewhere within range of the total sum of the weights.
+            float sum = Weights.Sum();
+            float result = (float)(s_random.NextDouble() * sum);
+
+            for (int i = 0; i < Prefabs.Length; i++)
+            {
+                // Check if result is under the weight.
+                // If not, remove the weight from it so it can be checked
+                // against the next weight.
+                if (result < Weights[i])
+                {
+                    return i;
+                }
+
+                result -= Weights[i];
+            }
+
+            // With the exclusive upper bound of NextDouble() this should never happen.
+            Debug.LogWarning("Reached end of spawning loop with no spawning, selecting last prefab");
+            return Prefabs.Length - 1;
+        }
+
+        public (bool X, bool Y, bool Z) GetFlips()
+        {
+            return (s_random.NextDouble() < ChanceX,
+                s_random.NextDouble() < ChanceY,
+                s_random.NextDouble() < ChanceZ);
+        }
+
+        public float[] GetPercentagesFromWeights()
+        {
+            float sum = Weights.Sum();
+            float[] percents = new float[Prefabs.Length];
+
+            // If there's no chance for anything, return 0% except for the
+            // last, since it will always be picked (with a warning).
+            if (sum == 0)
+            {
+                percents[percents.Length - 1] = 1.0f;
+                return percents;
+            }
+
+            for (int i = 0; i < Prefabs.Length; i++)
+            {
+                percents[i] = Weights[i] / sum;
+            }
+
+            return percents;
+        }
+    }
+}


### PR DESCRIPTION
This adds a random prefab picker component so cargo can use a random prefab within the cargo prefabs themselves.
It's useful for cargos that would otherwise have too many iterations for prefabs, like autoracks.
For that example, instead of having 6 slots for cars each with 8 possible colours (for a grand total of 8<sup>6</sup>, over 262k combinations), it's possible to procedurally spawn the colours at their positions on the fly. 
Of course, it's still possible to make curated prefabs and just use those instead.
There is also a customisable chance of the prefab spawning flipped (rotated along one or more of its axis by 180 degrees), which increases variety even more.

Known bugs: even though muti-object editing of the component is supported, the prefab array does not support it.