### PR TITLE
Collider missing warnings

### DIFF
--- a/CCL.Creator/Validators/CarValidators.cs
+++ b/CCL.Creator/Validators/CarValidators.cs
@@ -352,9 +352,10 @@ namespace CCL.Creator.Validators
             // bounding collider
             var collision = collidersRoot.FindSafe(CarPartNames.COLLISION_ROOT);
             var collisionComp = collision ? collision!.GetComponent<BoxCollider>() : null;
+
             if (!(collision && collisionComp))
             {
-                yield return Result.Failed($"Cargo {model.name} bounding {CarPartNames.COLLISION_ROOT} collider is missing");
+                yield return Result.Warning($"Cargo {model.name} bounding {CarPartNames.COLLISION_ROOT} collider is missing");
             }
         }
 

--- a/CCL.Creator/Validators/CarValidators.cs
+++ b/CCL.Creator/Validators/CarValidators.cs
@@ -351,7 +351,7 @@ namespace CCL.Creator.Validators
 
             // bounding collider
             var collision = collidersRoot.FindSafe(CarPartNames.COLLISION_ROOT);
-            var collisionComp = collision ? collision!.GetComponentInChildren<BoxCollider>() : null;
+            var collisionComp = collision ? collision!.GetComponentInChildren<Collider>() : null;
 
             if (!(collision && collisionComp))
             {

--- a/CCL.Creator/Validators/CarValidators.cs
+++ b/CCL.Creator/Validators/CarValidators.cs
@@ -353,6 +353,13 @@ namespace CCL.Creator.Validators
             var collision = collidersRoot.FindSafe(CarPartNames.COLLISION_ROOT);
             var collisionComp = collision ? collision!.GetComponent<BoxCollider>() : null;
 
+            if (!collisionComp)
+            {
+                // If the root does not have a collider itself, accept it anyways if any of its
+                // children have one.
+                collisionComp = collision ? collision!.GetComponentInChildren<BoxCollider>() : null;
+            }
+
             if (!(collision && collisionComp))
             {
                 yield return Result.Warning($"Cargo {model.name} bounding {CarPartNames.COLLISION_ROOT} collider is missing");

--- a/CCL.Creator/Validators/CarValidators.cs
+++ b/CCL.Creator/Validators/CarValidators.cs
@@ -351,14 +351,7 @@ namespace CCL.Creator.Validators
 
             // bounding collider
             var collision = collidersRoot.FindSafe(CarPartNames.COLLISION_ROOT);
-            var collisionComp = collision ? collision!.GetComponent<BoxCollider>() : null;
-
-            if (!collisionComp)
-            {
-                // If the root does not have a collider itself, accept it anyways if any of its
-                // children have one.
-                collisionComp = collision ? collision!.GetComponentInChildren<BoxCollider>() : null;
-            }
+            var collisionComp = collision ? collision!.GetComponentInChildren<BoxCollider>() : null;
 
             if (!(collision && collisionComp))
             {


### PR DESCRIPTION
First commit changes cargo validator to only have a warning on missing bounding collider.
Second commit further forgives the validation by checking the children for colliders.