### PR TITLE
Working brake glows

### DIFF
--- a/CCL.Importer/PrefabWrangler.cs
+++ b/CCL.Importer/PrefabWrangler.cs
@@ -53,7 +53,6 @@ namespace CCL.Importer
             WrangleBogies(newFab, livery, baseLivery, colliders);
             CleanInfoPlates(newFab.transform);
             WrangleExternalInteractables(livery);
-            SetupBrakeGlows(newFab, baseLivery);
 
             UpdateLiveryShaders(livery);
 
@@ -584,6 +583,9 @@ namespace CCL.Importer
             }
 
             // TODO: apply rear bogie config
+
+            // Setup brake glows.
+            SetupBrakeGlows(newFab, frontBogie, rearBogie, baseCar);
         }
 
         private static Bogie StealBaseCarBogie(Transform carRoot, Transform newBogieTransform, Transform bogieColliderRoot,
@@ -610,14 +612,14 @@ namespace CCL.Importer
             return newBogie;
         }
 
-        private static void SetupBrakeGlows(GameObject newFab, TrainCarLivery baseLivery)
+        private static void SetupBrakeGlows(GameObject newFab, Bogie front, Bogie rear, TrainCarLivery baseLivery)
         {
             var brakeGlow = newFab.AddComponent<BrakesOverheatingController>();
             List<Renderer> brakeRenderers = new();
 
             // Front bogie pads.
-            Transform padsF = newFab.transform.Find(
-                $"{CarPartNames.BOGIE_FRONT}/{CarPartNames.BOGIE_CAR}/{CarPartNames.BOGIE_BRAKE_ROOT}/{CarPartNames.BOGIE_BRAKE_PADS}");
+            Transform padsF = front.transform.Find(
+                $"{CarPartNames.BOGIE_CAR}/{CarPartNames.BOGIE_BRAKE_ROOT}/{CarPartNames.BOGIE_BRAKE_PADS}");
 
             if (padsF != null)
             {
@@ -627,8 +629,8 @@ namespace CCL.Importer
             }
 
             // Rear bogie pads.
-            Transform padsR = newFab.transform.Find(
-                $"{CarPartNames.BOGIE_REAR}/{CarPartNames.BOGIE_CAR}/{CarPartNames.BOGIE_BRAKE_ROOT}/{CarPartNames.BOGIE_BRAKE_PADS}");
+            Transform padsR = rear.transform.Find(
+                $"{CarPartNames.BOGIE_CAR}/{CarPartNames.BOGIE_BRAKE_ROOT}/{CarPartNames.BOGIE_BRAKE_PADS}");
 
             if (padsR != null)
             {

--- a/CCL.Types/CarPartNames.cs
+++ b/CCL.Types/CarPartNames.cs
@@ -46,6 +46,8 @@
         public const string BOGIE_FRONT = "BogieF";
         public const string BOGIE_REAR = "BogieR";
         public const string BOGIE_CAR = "bogie_car";
+        public const string BOGIE_BRAKE_ROOT = "bogie2brakes";
+        public const string BOGIE_BRAKE_PADS = "Bogie2BrakePads";
 
         // Info Plates
         public static readonly string[] INFO_PLATES = { "[car plate anchor1]", "[car plate anchor2]" };

--- a/CCL.Types/CustomBrakeGlow.cs
+++ b/CCL.Types/CustomBrakeGlow.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+
+namespace CCL.Types
+{
+    public class CustomBrakeGlow : MonoBehaviour
+    {
+        [GradientUsage(true)]
+        public Gradient ColourGradient;
+    }
+}


### PR DESCRIPTION
Simulator update adds a new script to the train car that handles brakes glowing when overheating. This script was missing from the car prefab itself, so it's added.
The rest of the code finds the actual brake pad mesh renderers (found at `bogie_car/bogie2brakes/Bogie2BrakePads` in vanilla), and assigns them.
As a final note, I also added a CustomBrakeGlow component that can be added to the root of the prefab, and when added the specified gradient will be used for the glows instead of the one from the base car type.