### PR TITLE
Destroy buffer stem model from base livery.

### DIFF
--- a/CCL.Importer/PrefabWrangler.cs
+++ b/CCL.Importer/PrefabWrangler.cs
@@ -186,7 +186,7 @@ namespace CCL.Importer
                 else if (CarPartNames.BUFFER_STEMS.Equals(childName))
                 {
                     // stems
-                    continue;
+                    Object.Destroy(child.gameObject);
                 }
                 else if (CarPartNames.BUFFER_FRONT_PADS.Contains(childName))
                 {


### PR DESCRIPTION
Simply destroys the buffer stems model child instead of ignoring it.