### PR TITLE
Fixed cars getting unloaded when reloading saves.

### DIFF
--- a/CCL.Creator/Editor/CarPrefabManipulators.cs
+++ b/CCL.Creator/Editor/CarPrefabManipulators.cs
@@ -143,9 +143,10 @@ namespace CCL.Creator.Editor
                 case BaseTrainCarType.NotSet:
                 case BaseTrainCarType.LocoShunter:
                 case BaseTrainCarType.LocoDM3:
+                case BaseTrainCarType.LocoRailbus:
                 case BaseTrainCarType.LocoS060:
                 case BaseTrainCarType.LocoSteamHeavy:
-                case BaseTrainCarType.LocoRailbus:
+                case BaseTrainCarType.HandCar:
                     return 0.00f;
                 default:
                     return 1.00f;

--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -137,6 +137,8 @@ namespace CCL.Importer
 
                 CCLPlugin.Log($"Successfully loaded car type {carId}");
 
+                assetBundle.Unload(false);
+
                 return carType;
             }
             catch (Exception ex)

--- a/CCL.Importer/Processing/BogieProcessor.cs
+++ b/CCL.Importer/Processing/BogieProcessor.cs
@@ -3,7 +3,6 @@ using CCL.Types.Components;
 using CCL.Types.Proxies.Wheels;
 using DV.Simulation.Brake;
 using DV.ThingTypes;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -71,10 +70,10 @@ namespace CCL.Importer.Processing
             CapsuleCollider baseBogieCollider, Bogie origBogie)
         {
             Vector3 bogiePosition = newBogieTransform.localPosition;
-            UnityEngine.Object.Destroy(newBogieTransform.gameObject);
+            Object.Destroy(newBogieTransform.gameObject);
 
             //GameObject origBogie = baseCar.Bogies[0].gameObject;
-            GameObject copiedObject = UnityEngine.Object.Instantiate(origBogie.gameObject, carRoot);
+            GameObject copiedObject = Object.Instantiate(origBogie.gameObject, carRoot);
             copiedObject.name = CarPartNames.BOGIE_FRONT;
             copiedObject.transform.localPosition = bogiePosition;
 
@@ -170,7 +169,7 @@ namespace CCL.Importer.Processing
 
             var temp = controller.gameObject.AddComponent<DV.Wheels.WheelSlideSparksController>();
             temp.sparkAnchors = controller.sparkAnchors.Where(x => ProcessSparkAnchor(x, front.transform, rear.transform)).ToArray();
-            UnityEngine.Object.Destroy(controller);
+            Object.Destroy(controller);
         }
 
         private static bool ProcessSparkAnchor(Transform anchor, Transform frontBogie, Transform rearBogie)

--- a/CCL.Importer/Processing/ModelProcessor.cs
+++ b/CCL.Importer/Processing/ModelProcessor.cs
@@ -1,7 +1,6 @@
 ﻿using CCL.Importer.Types;
 using CCL.Types;
 using DV;
-using DV.Logic.Job;
 using DV.ThingTypes;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -12,8 +11,6 @@ using UnityEngine;
 
 namespace CCL.Importer.Processing
 {
-    using UObject = UnityEngine.Object;
-
     internal class ModelProcessor
     {
         private static readonly AggregateCatalog _catalog;
@@ -95,7 +92,7 @@ namespace CCL.Importer.Processing
 
         public static GameObject CreateModifiablePrefab(GameObject gameObject)
         {
-            GameObject newFab = UObject.Instantiate(gameObject, null);
+            GameObject newFab = Object.Instantiate(gameObject, null);
 
             // Get enabled state of components on prefab.
             // Unity disables the attached components on a GameObject when
@@ -104,7 +101,7 @@ namespace CCL.Importer.Processing
             var states = newFab.GetComponents<MonoBehaviour>().ToDictionary(k => k, v => v.enabled);
 
             newFab.SetActive(false);
-            UObject.DontDestroyOnLoad(newFab);
+            Object.DontDestroyOnLoad(newFab);
 
             // Restore state.
             foreach (var state in states)

--- a/CCL.Importer/Types/WheelRotationViaAnimation.cs
+++ b/CCL.Importer/Types/WheelRotationViaAnimation.cs
@@ -9,7 +9,7 @@ namespace CCL.Importer.Types
 
         private const string SPEED = "SpeedMultiplier";
 
-        private static readonly int SPEED_ID = Animator.StringToHash("SpeedMultiplier");
+        private static readonly int SPEED_ID = Animator.StringToHash(SPEED);
 
         protected override void Awake()
         {


### PR DESCRIPTION
Added Handcart case to bogie alignment.
Cleaned up some code.

About the cars getting unloaded. I don't actually know how it works.
I believe DV will force unload an asset bundle it believes unused with [`unloadAllLoadedObjects`](https://docs.unity3d.com/ScriptReference/AssetBundle.Unload.html) set to true as a resource saving measure. This would cause all already loaded models, textures, etc, from a car to get force unloaded. So instead of allowing the game to unload the bundle, we unload it first ourselves with that parameter set to false.
As such, the game will not find a bundle to unload, and the assets we loaded will stay.
In addition to this, I believe this opens the possibility of hotreloading in the future, as we can load the same asset bundle again.
However, I have no knowledge on this matter, and this was just a lucky guess.