### PR TITLE
Added ability to process extra prefabs not referenced directly

### DIFF
--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -158,6 +158,13 @@ namespace CCL.Importer
                 }
             }
 
+            CCLPlugin.Log($"Extra models: {carType.ExtraModels.Length}");
+
+            foreach (var extraModel in carType.ExtraModels)
+            {
+                ModelProcessor.DoBasicProcessing(extraModel);
+            }
+
             return true;
         }
 

--- a/CCL.Importer/CargoInjector.cs
+++ b/CCL.Importer/CargoInjector.cs
@@ -30,13 +30,7 @@ namespace CCL.Importer
                 {
                     for (int i = 0; i < loadableCargo.ModelVariants.Length; i++)
                     {
-                        CCLPlugin.LogVerbose($"Deserializing");
-                        ModelProcessor.HandleCustomSerialization(loadableCargo.ModelVariants[i]);
-                        CCLPlugin.LogVerbose($"Processing grabbers");
-                        GrabberProcessor.ProcessGrabbersOnPrefab(loadableCargo.ModelVariants[i]);
-                        CCLPlugin.LogVerbose($"Processing proxies");
-                        Mapper.ProcessConfigs(loadableCargo.ModelVariants[i]);
-                        Mapper.ClearComponentCache();
+                        ModelProcessor.DoBasicProcessing(loadableCargo.ModelVariants[i]);
                     }
                 }
 

--- a/CCL.Importer/Processing/GrabberProcessor.cs
+++ b/CCL.Importer/Processing/GrabberProcessor.cs
@@ -175,8 +175,6 @@ namespace CCL.Importer.Processing
                     {
                         string name = MaterialGrabber.MaterialNames[index.NameIndex];
 
-                        CCLPlugin.Log(name);
-
                         if (s_materialCache.Cache.TryGetValue(name, out Material mat))
                         {
                             if (index.RendererIndex < renderer.sharedMaterials.Length)

--- a/CCL.Importer/Processing/ModelProcessor.cs
+++ b/CCL.Importer/Processing/ModelProcessor.cs
@@ -119,5 +119,14 @@ namespace CCL.Importer.Processing
                 component.AfterImport();
             }
         }
+
+        public static void DoBasicProcessing(GameObject prefab)
+        {
+            CCLPlugin.LogVerbose($"Deserializing, processing grabbers and proxies for {prefab.name}");
+            HandleCustomSerialization(prefab);
+            GrabberProcessor.ProcessGrabbersOnPrefab(prefab);
+            Mapper.ProcessConfigs(prefab);
+            Mapper.ClearComponentCache();
+        }
     }
 }

--- a/CCL.Importer/Types/CCL_CarType.cs
+++ b/CCL.Importer/Types/CCL_CarType.cs
@@ -14,6 +14,7 @@ namespace CCL.Importer.Types
         public DVTrainCarKind KindSelection;
         public TranslationData NameTranslations = new();
         public LoadableCargo? CargoTypes;
+        public GameObject[] ExtraModels = new GameObject[0];
 
         public IEnumerable<GameObject> AllCargoModels
         {

--- a/CCL.Types/CustomCarType.cs
+++ b/CCL.Types/CustomCarType.cs
@@ -54,6 +54,9 @@ namespace CCL.Types
         public BrakesSetup brakes;
         public DamageSetup damage;
 
+        [Tooltip("Any extra prefab that has scripts on it should be added here")]
+        public GameObject[] ExtraModels = new GameObject[0];
+
         [SerializeField, HideInInspector]
         private string? brakesJson;
         [SerializeField, HideInInspector]


### PR DESCRIPTION
That includes exploded prefabs, cargo with no health, etc.
Cleaned up printing names in `GrabberProcessor`.