### PR TITLE
MU cable

### DIFF
--- a/CCL.Importer/Processing/BufferProcessor.cs
+++ b/CCL.Importer/Processing/BufferProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using CCL.Importer.Types;
 using CCL.Types;
+using CCL.Types.Proxies;
 using DV.MultipleUnit;
 using DV.ThingTypes;
 using DV.ThingTypes.TransitionHelpers;
@@ -90,6 +91,11 @@ namespace CCL.Importer.Processing
             foreach (var item in ogControllers)
             {
                 Object.Destroy(item.gameObject);
+            }
+
+            if (!bufferRoot.transform.root.GetComponentInChildren<MultipleUnitStateObserverProxy>())
+            {
+                bufferRoot.transform.root.gameObject.AddComponent<MultipleUnitStateObserverProxy>();
             }
         }
 

--- a/CCL.Importer/Proxies/MiscReplacer.cs
+++ b/CCL.Importer/Proxies/MiscReplacer.cs
@@ -3,6 +3,7 @@ using CCL.Types;
 using CCL.Types.Proxies;
 using DV;
 using DV.Interaction;
+using DV.Simulation.Cars;
 using DV.ThingTypes.TransitionHelpers;
 using UnityEngine;
 
@@ -41,6 +42,8 @@ namespace CCL.Importer.Proxies
             CreateMap<TeleportHoverGlowProxy, TeleportHoverGlow>().AutoCacheAndMap()
                 .AfterMap(TeleportHoverGlowAfter);
             CreateMap<GrabberRaycastPassThroughProxy, GrabberRaycastPassThrough>().AutoCacheAndMap();
+
+            CreateMap<MultipleUnitStateObserverProxy, MultipleUnitStateObserver>().AutoCacheAndMap();
         }
 
         private void InteriorNonStandardLayerAfter(InteriorNonStandardLayerProxy src, InteriorNonStandardLayer dest)

--- a/CCL.Importer/Types/CCL_CarVariant.cs
+++ b/CCL.Importer/Types/CCL_CarVariant.cs
@@ -15,6 +15,7 @@ namespace CCL.Importer.Types
         public BogieType RearBogie;
 
         public BufferType BufferType;
+        public bool HasMUCable;
         public bool UseCustomHosePositions;
 
         public bool HideFrontCoupler;

--- a/CCL.Types/BogieBufferTypes.cs
+++ b/CCL.Types/BogieBufferTypes.cs
@@ -23,7 +23,7 @@ namespace CCL.Types
         [Tooltip("Used by Gondola, S060")]
         Buffer04        = 550,
         [Tooltip("Used by DE6, DE6 Slug, Microshunter")]
-        Buffer05        = 40,
+        Buffer05        = 70,
         [Tooltip("Used by Boxcar Military, Refrigerator")]
         Buffer06        = 450,
         [Tooltip("Used by Caboose, Tank, Short Tank")]

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -36,6 +36,7 @@ namespace CCL.Types
 
         [Header("Buffers")]
         public BufferType BufferType = BufferType.Buffer09;
+        public bool HasMUCable = false;
         public bool UseCustomHosePositions = false;
 
         public bool HideFrontCoupler = false;

--- a/CCL.Types/Proxies/MultipleUnitStateObserverProxy.cs
+++ b/CCL.Types/Proxies/MultipleUnitStateObserverProxy.cs
@@ -1,0 +1,16 @@
+﻿using CCL.Types.Proxies.Ports;
+using UnityEngine;
+
+namespace CCL.Types.Proxies
+{
+    public class MultipleUnitStateObserverProxy : MonoBehaviour
+    {
+        [Header("optional")]
+        [PortId(DVPortValueType.TEMPERATURE, false)]
+        public string temperaturePortId;
+        [SerializeField]
+        private float overheatStandardThreshold = 90f;
+        [SerializeField]
+        private float overheatCriticalThreshold = 105f;
+    }
+}


### PR DESCRIPTION
Adds an option to each livery to enable the MU cable on it. Enabling this will swap the coupling rig with the MU rig.
Changed DE6 buffer to use the Microshunter version since it has no MU cable, so it doesn't have to be changed to non-MU version.
Added MU Observer. This is required for MU to work, but it only has optional settings. As such, it will be automatically added if it doesn't exist in a prefab that has MU enabled.

Some measures were taken to handle the S282's couplers but it will probably still break on those.