### PR TITLE
Quick cargo amount access and validation.

### DIFF
--- a/CCL.Creator/Validators/CargoValidator.cs
+++ b/CCL.Creator/Validators/CargoValidator.cs
@@ -1,4 +1,5 @@
 ﻿using CCL.Types;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace CCL.Creator.Validators
@@ -15,6 +16,9 @@ namespace CCL.Creator.Validators
             }
 
             var result = Pass();
+            var hashCargo = new HashSet<BaseCargoType>();
+            var hashId = new HashSet<string>();
+
             foreach (var cargo in car.CargoTypes.Entries)
             {
                 if (cargo.AmountPerCar <= 0)
@@ -24,6 +28,28 @@ namespace CCL.Creator.Validators
                 if (cargo.CargoType == BaseCargoType.None)
                 {
                     result.Fail("Cannot load cargo of type None");
+                }
+                else if (cargo.IsCustom)
+                {
+                    if (hashId.Contains(cargo.CustomCargoId))
+                    {
+                        result.Warning($"Repeated instance of custom cargo {cargo.CustomCargoId}");
+                    }
+                    else
+                    {
+                        hashId.Add(cargo.CustomCargoId);
+                    }
+                }
+                else
+                {
+                    if (hashCargo.Contains(cargo.CargoType))
+                    {
+                        result.Warning($"Repeated instance of cargo {cargo.CustomCargoId}");
+                    }
+                    else
+                    {
+                        hashCargo.Add(cargo.CargoType);
+                    }
                 }
 
                 if (cargo.ModelVariants != null)

--- a/CCL.Creator/Validators/CargoValidator.cs
+++ b/CCL.Creator/Validators/CargoValidator.cs
@@ -33,7 +33,7 @@ namespace CCL.Creator.Validators
                 {
                     if (hashId.Contains(cargo.CustomCargoId))
                     {
-                        result.Warning($"Repeated instance of custom cargo {cargo.CustomCargoId}");
+                        result.Warning($"Repeated instance of custom cargo '{cargo.CustomCargoId}'");
                     }
                     else
                     {
@@ -44,7 +44,7 @@ namespace CCL.Creator.Validators
                 {
                     if (hashCargo.Contains(cargo.CargoType))
                     {
-                        result.Warning($"Repeated instance of cargo {cargo.CustomCargoId}");
+                        result.Warning($"Repeated instance of cargo '{cargo.CargoType}'");
                     }
                     else
                     {

--- a/CCL.Importer/Patches/StationProceduralJobGeneratorPatches.cs
+++ b/CCL.Importer/Patches/StationProceduralJobGeneratorPatches.cs
@@ -11,7 +11,7 @@ namespace CCL.Importer.Patches
     [HarmonyPatch(typeof(StationProceduralJobGenerator))]
     internal class StationProceduralJobGeneratorPatches
     {
-        [HarmonyPostfix, HarmonyPatch(nameof(StationProceduralJobGenerator.GenerateBaseCargoTrainData))]
+        //[HarmonyPostfix, HarmonyPatch(nameof(StationProceduralJobGenerator.GenerateBaseCargoTrainData))]
         public static void GenerateBaseCargoTrainDataPostfix(List<CarTypesPerCargoTypeData> __result)
         {
             for (int i = 0; i < __result.Count; i++)

--- a/CCL.Importer/Patches/StationProceduralJobGeneratorPatches.cs
+++ b/CCL.Importer/Patches/StationProceduralJobGeneratorPatches.cs
@@ -1,0 +1,46 @@
+﻿using CCL.Importer.Types;
+using DV.ThingTypes;
+using HarmonyLib;
+using System.Collections.Generic;
+using UnityEngine;
+
+using static StationProceduralJobGenerator;
+
+namespace CCL.Importer.Patches
+{
+    [HarmonyPatch(typeof(StationProceduralJobGenerator))]
+    internal class StationProceduralJobGeneratorPatches
+    {
+        [HarmonyPostfix, HarmonyPatch(nameof(StationProceduralJobGenerator.GenerateBaseCargoTrainData))]
+        public static void GenerateBaseCargoTrainDataPostfix(List<CarTypesPerCargoTypeData> __result)
+        {
+            for (int i = 0; i < __result.Count; i++)
+            {
+                float totalAmount = 0;
+
+                foreach (var car in __result[i].carTypes)
+                {
+                    if (car is CCL_CarVariant variant)
+                    {
+                        totalAmount += GetCargoAmount((CCL_CarType)variant.parentType, __result[i].cargoType);
+                    }
+                }
+
+                if (!Mathf.Approximately(totalAmount, __result[i].totalCargoAmount))
+                {
+                    __result[i] = new CarTypesPerCargoTypeData(__result[i].carTypes, __result[i].cargoType, totalAmount);
+                }
+            }
+        }
+
+        private static float GetCargoAmount(CCL_CarType carType, CargoType cargo)
+        {
+            if (carType.CargoAmounts.TryGetValue(cargo, out float amount))
+            {
+                return amount;
+            }
+
+            return 1.0f;
+        }
+    }
+}

--- a/CCL.Importer/Patches/StationProceduralJobGeneratorPatches.cs
+++ b/CCL.Importer/Patches/StationProceduralJobGeneratorPatches.cs
@@ -1,5 +1,6 @@
 ﻿using CCL.Importer.Types;
 using DV.ThingTypes;
+using DV.ThingTypes.TransitionHelpers;
 using HarmonyLib;
 using System.Collections.Generic;
 using UnityEngine;
@@ -35,7 +36,7 @@ namespace CCL.Importer.Patches
 
         private static float GetCargoAmount(CCL_CarType carType, CargoType cargo)
         {
-            if (carType.CargoAmounts.TryGetValue(cargo, out float amount))
+            if (carType.CargoAmounts.TryGetValue(cargo.ToV2().id, out float amount))
             {
                 return amount;
             }

--- a/CCL.Importer/Types/CCL_CarType.cs
+++ b/CCL.Importer/Types/CCL_CarType.cs
@@ -1,6 +1,5 @@
 ﻿using CCL.Types;
 using DV;
-using DV.Logic.Job;
 using DV.ThingTypes;
 using DVLangHelper.Data;
 using System.Collections.Generic;

--- a/CCL.Importer/Types/CCL_CarType.cs
+++ b/CCL.Importer/Types/CCL_CarType.cs
@@ -1,6 +1,7 @@
 ﻿using CCL.Types;
 using DV;
 using DV.ThingTypes;
+using DV.ThingTypes.TransitionHelpers;
 using DVLangHelper.Data;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,8 +21,8 @@ namespace CCL.Importer.Types
 
         public GameObject SimAudioPrefab;
 
-        private Dictionary<CargoType, float>? _cargoAmounts;
-        public Dictionary<CargoType, float> CargoAmounts => Extensions.GetCached(ref _cargoAmounts, GenerateCargoAmounts);
+        private Dictionary<string, float>? _cargoAmounts;
+        public Dictionary<string, float> CargoAmounts => Extensions.GetCached(ref _cargoAmounts, GenerateCargoAmounts);
 
         public IEnumerable<GameObject> AllCargoModels
         {
@@ -41,9 +42,9 @@ namespace CCL.Importer.Types
             }
         }
 
-        private Dictionary<CargoType, float> GenerateCargoAmounts()
+        private Dictionary<string, float> GenerateCargoAmounts()
         {
-            Dictionary<CargoType, float> dict = new();
+            Dictionary<string, float> dict = new();
 
             if (CargoTypes == null || CargoTypes.IsEmpty)
             {
@@ -52,13 +53,13 @@ namespace CCL.Importer.Types
 
             foreach (var item in CargoTypes.Entries)
             {
-                CargoType c;
+                string id;
 
                 if (item.IsCustom)
                 {
-                    if (Globals.G.types.TryGetCargo(item.CustomCargoId, out var cargo))
+                    if (Globals.G.types.TryGetCargo(item.CustomCargoId, out _))
                     {
-                        c = cargo.v1;
+                        id = item.CustomCargoId;
                     }
                     else
                     {
@@ -67,12 +68,12 @@ namespace CCL.Importer.Types
                 }
                 else
                 {
-                    c = (CargoType)item.CargoType;
+                    id = ((CargoType)item.CargoType).ToV2().id;
                 }
 
-                if (!dict.ContainsKey(c))
+                if (!dict.ContainsKey(id))
                 {
-                    dict.Add(c, item.AmountPerCar);
+                    dict.Add(id, item.AmountPerCar);
                 }
             }
 

--- a/CCL.Importer/Types/CCL_CarType.cs
+++ b/CCL.Importer/Types/CCL_CarType.cs
@@ -1,4 +1,6 @@
 ﻿using CCL.Types;
+using DV;
+using DV.Logic.Job;
 using DV.ThingTypes;
 using DVLangHelper.Data;
 using System.Collections.Generic;
@@ -19,6 +21,9 @@ namespace CCL.Importer.Types
 
         public GameObject SimAudioPrefab;
 
+        private Dictionary<CargoType, float>? _cargoAmounts;
+        public Dictionary<CargoType, float> CargoAmounts => Extensions.GetCached(ref _cargoAmounts, GenerateCargoAmounts);
+
         public IEnumerable<GameObject> AllCargoModels
         {
             get
@@ -35,6 +40,44 @@ namespace CCL.Importer.Types
                     }
                 }
             }
+        }
+
+        private Dictionary<CargoType, float> GenerateCargoAmounts()
+        {
+            Dictionary<CargoType, float> dict = new();
+
+            if (CargoTypes == null || CargoTypes.IsEmpty)
+            {
+                return dict;
+            }
+
+            foreach (var item in CargoTypes.Entries)
+            {
+                CargoType c;
+
+                if (item.IsCustom)
+                {
+                    if (Globals.G.types.TryGetCargo(item.CustomCargoId, out var cargo))
+                    {
+                        c = cargo.v1;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+                else
+                {
+                    c = (CargoType)item.CargoType;
+                }
+
+                if (!dict.ContainsKey(c))
+                {
+                    dict.Add(c, item.AmountPerCar);
+                }
+            }
+
+            return dict;
         }
     }
 }


### PR DESCRIPTION
This was supposed to be part of the cargo amount fix, but that requires substantially more work. The patch that was the start of it is commented out so it does not affect the game, but was kept in case it can be used later.

Validation was added to the cargo entries to warn on duplicates, since only the first entry is added.