### PR TITLE
DH Sim

### DIFF
--- a/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
@@ -54,7 +54,7 @@ namespace CCL.Creator.Wizards.SimSetup
             {
                 bellControl = CreateExternalControl("bellControl", true);
                 bell = CreateSimComponent<ElectricBellDefinitionProxy>("bell");
-                bell.smoothDownTime = 0.05f;
+                bell.smoothDownTime = 0.5f;
             }
 
             var fuel = CreateResourceContainer(ResourceContainerType.Fuel);

--- a/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
@@ -9,7 +9,6 @@ using CCL.Types.Proxies.Simulation.Diesel;
 using CCL.Types.Proxies.Simulation.Electric;
 using CCL.Types.Proxies.Wheels;
 using UnityEngine;
-using static CCL.Types.CarPartNames;
 
 namespace CCL.Creator.Wizards.SimSetup
 {
@@ -35,12 +34,16 @@ namespace CCL.Creator.Wizards.SimSetup
             var indBrake = CreateOverridableControl(OverridableControlType.IndBrake);
             var dynBrake = hasDynamic ? CreateOverridableControl(OverridableControlType.DynamicBrake) : null!;
 
+            // Headlights.
+
             var fuel = CreateResourceContainer(ResourceContainerType.Fuel);
             var oil = CreateResourceContainer(ResourceContainerType.Oil);
             var sand = CreateResourceContainer(ResourceContainerType.Sand);
             var sander = CreateSanderControl();
 
             var engine = CreateSimComponent<DieselEngineDirectDefinitionProxy>("de");
+            var engineOff = CreateSibling<OverridableControlProxy>(engine);
+            engineOff.portId = FullPortId(engine, "EMERGENCY_ENGINE_OFF_EXT_IN");
             var engineOn = CreateSibling<EngineOnReaderProxy>(engine);
             engineOn.portId = FullPortId(engine, "ENGINE_ON");
             var environmentDamage = CreateSibling<EnvironmentDamagerProxy>(engine);

--- a/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
@@ -10,6 +10,8 @@ using CCL.Types.Proxies.Simulation.Electric;
 using CCL.Types.Proxies.Wheels;
 using UnityEngine;
 
+using static CCL.Types.Proxies.Controls.ControlBlockerProxy.BlockerDefinition;
+
 namespace CCL.Creator.Wizards.SimSetup
 {
     internal class DieselElectricSimCreator : SimCreator
@@ -199,18 +201,19 @@ namespace CCL.Creator.Wizards.SimSetup
             _damageController.electricalPTDamagerPortIds = new[] { FullPortId(tm, "GENERATED_DAMAGE") };
             _damageController.electricalPTHealthStateExternalInPortIds = new[] { FullPortId(tm, "HEALTH_STATE_EXT_IN") };
 
-            AddControlBlocker(reverser.GetComponent<OverridableControlProxy>(),
-                throttle, "EXT_IN", 0, ControlBlockerProxy.BlockerDefinition.BlockType.BLOCK_ON_ABOVE_THRESHOLD);
+            AddControlBlocker(reverser, throttle, "EXT_IN", 0, BlockType.BLOCK_ON_ABOVE_THRESHOLD)
+                .blockedControlPortId = FullPortId(reverser, "CONTROL_EXT_IN");
 
             if (hasDynamic)
             {
-                AddControlBlocker(reverser.GetComponent<OverridableControlProxy>(),
-                    dynBrake, "EXT_IN", 0, ControlBlockerProxy.BlockerDefinition.BlockType.BLOCK_ON_ABOVE_THRESHOLD);
+                AddControlBlocker(reverser, dynBrake, "EXT_IN", 0, BlockType.BLOCK_ON_ABOVE_THRESHOLD);
 
-                AddControlBlocker(throttle, dynBrake, "EXT_IN", 0, ControlBlockerProxy.BlockerDefinition.BlockType.BLOCK_ON_ABOVE_THRESHOLD);
+                AddControlBlocker(throttle, dynBrake, "EXT_IN", 0, BlockType.BLOCK_ON_ABOVE_THRESHOLD)
+                    .blockedControlPortId = FullPortId(throttle, "EXT_IN");
 
-                AddControlBlocker(dynBrake, throttle, "EXT_IN", 0, ControlBlockerProxy.BlockerDefinition.BlockType.BLOCK_ON_ABOVE_THRESHOLD);
-                AddControlBlocker(dynBrake, reverser, "REVERSER", 0, ControlBlockerProxy.BlockerDefinition.BlockType.BLOCK_ON_EQUAL_TO_THRESHOLD);
+                AddControlBlocker(dynBrake, throttle, "EXT_IN", 0, BlockType.BLOCK_ON_ABOVE_THRESHOLD);
+                AddControlBlocker(dynBrake, reverser, "REVERSER", 0, BlockType.BLOCK_ON_EQUAL_TO_THRESHOLD)
+                    .blockedControlPortId = FullPortId(dynBrake, "EXT_IN");
             }
         }
 

--- a/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
@@ -1,0 +1,110 @@
+﻿using CCL.Types;
+using CCL.Types.Proxies;
+using CCL.Types.Proxies.Controllers;
+using CCL.Types.Proxies.Controls;
+using CCL.Types.Proxies.Ports;
+using CCL.Types.Proxies.Resources;
+using CCL.Types.Proxies.Simulation;
+using CCL.Types.Proxies.Simulation.Diesel;
+using CCL.Types.Proxies.Simulation.Electric;
+using CCL.Types.Proxies.Wheels;
+using UnityEngine;
+
+namespace CCL.Creator.Wizards.SimSetup
+{
+    internal class DieselHydraulicSimCreator : SimCreator
+    {
+        public DieselHydraulicSimCreator(GameObject prefabRoot) : base(prefabRoot) { }
+
+        public override string[] SimBasisOptions => new[] { "DH4" };
+
+        public override void CreateSimForBasisImpl(int basisIndex)
+        {
+            var throttle = CreateOverridableControl(OverridableControlType.Throttle);
+            var thrtPowr = CreateSimComponent<ThrottleGammaPowerConversionDefinitionProxy>("throttlePower");
+            var reverser = CreateReverserControl();
+            var trnBrake = CreateOverridableControl(OverridableControlType.TrainBrake);
+            var indBrake = CreateOverridableControl(OverridableControlType.IndBrake);
+            var dynBrake = CreateOverridableControl(OverridableControlType.DynamicBrake);
+
+            var genericHornControl = CreateSimComponent<GenericControlDefinitionProxy>("hornControl");
+            genericHornControl.defaultValue = 0;
+            genericHornControl.smoothTime = 0.2f;
+            var hornControl = CreateSibling<HornControlProxy>(genericHornControl);
+            hornControl.portId = FullPortId(genericHornControl, "EXT_IN");
+            hornControl.neutralAt0 = true;
+            var horn = CreateSimComponent<HornDefinitionProxy>("horn");
+            horn.controlNeutralAt0 = true;
+
+            var bellControl = CreateExternalControl("bellControl", true);
+            var bell = CreateSimComponent<ElectricBellDefinitionProxy>("bell");
+            bell.smoothDownTime = 0.05f;
+
+            // Headlights.
+
+            var fuel = CreateResourceContainer(ResourceContainerType.Fuel);
+            var oil = CreateResourceContainer(ResourceContainerType.Oil);
+            var sand = CreateResourceContainer(ResourceContainerType.Sand);
+            var sander = CreateSanderControl();
+
+            var engine = CreateSimComponent<DieselEngineDirectDefinitionProxy>("de");
+            var engineOff = CreateSibling<OverridableControlProxy>(engine);
+            engineOff.portId = FullPortId(engine, "EMERGENCY_ENGINE_OFF_EXT_IN");
+            var engineOn = CreateSibling<EngineOnReaderProxy>(engine);
+            engineOn.portId = FullPortId(engine, "ENGINE_ON");
+            var environmentDamage = CreateSibling<EnvironmentDamagerProxy>(engine);
+            environmentDamage.damagerPortId = FullPortId(engine, "FUEL_ENV_DAMAGE_METER");
+            environmentDamage.environmentDamageResource = BaseResourceType.EnvironmentDamageFuel;
+            var engineExplosion = CreateSibling<ExplosionActivationOnSignalProxy>(engine);
+            engineExplosion.explosion = ExplosionPrefab.ExplosionMechanical;
+            engineExplosion.bodyDamagePercentage = 0.1f;
+            engineExplosion.explosionSignalPortId = FullPortId(engine, "IS_BROKEN");
+
+            var loadTorque = CreateSimComponent<ConfigurableAddDefinitionProxy>("loadTorqueCalculator");
+            loadTorque.aReader = new PortReferenceDefinition(DVPortValueType.TORQUE, "LOAD_TORQUE_0");
+            loadTorque.bReader = new PortReferenceDefinition(DVPortValueType.TORQUE, "LOAD_TORQUE_1");
+            loadTorque.addReadOut = new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.TORQUE, "LOAD_TORQUE_TOTAL");
+            loadTorque.transform.parent = engine.transform;
+
+            var compressor = CreateSimComponent<MechanicalCompressorDefinitionProxy>("compressor");
+            var airController = CreateCompressorSim(compressor);
+
+            var fluidCoupler = CreateSimComponent<HydraulicTransmissionDefinitionProxy>("fluidCoupler");
+            var couplerExplosion = CreateSibling<ExplosionActivationOnSignalProxy>(fluidCoupler);
+            couplerExplosion.explosion = ExplosionPrefab.ExplosionHydraulic;
+            couplerExplosion.bodyDamagePercentage = 0.1f;
+            couplerExplosion.windowsBreakingDelay = 0.4f;
+            couplerExplosion.explosionSignalPortId = FullPortId(fluidCoupler, "IS_BROKEN");
+
+            var cooler = CreateSimComponent<PassiveCoolerDefinitionProxy>("fcCooler");
+            cooler.transform.parent = fluidCoupler.transform;
+            var autoCooler = CreateSimComponent<AutomaticCoolerDefinitionProxy>("fcAutomaticCooler");
+            autoCooler.transform.parent = fluidCoupler.transform;
+            var heat = CreateSimComponent<HeatReservoirDefinitionProxy>("coolant");
+            heat.transform.parent = fluidCoupler.transform;
+            heat.inputCount = 4;
+            heat.OnValidate();
+
+            var poweredAxles = CreateSimComponent<ConstantPortDefinitionProxy>("poweredAxles");
+            poweredAxles.value = 4;
+            poweredAxles.port = new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.GENERIC, "NUM");
+
+            var transmission = CreateSimComponent<TransmissionFixedGearDefinitionProxy>("transmission");
+            var traction = CreateSimComponent<TractionDefinitionProxy>("traction");
+            var tractionFeeders = CreateTractionFeeders(traction);
+            var wheelslip = CreateSibling<WheelslipControllerProxy>(traction);
+            wheelslip.numberOfPoweredAxlesPortId = FullPortId(poweredAxles, "NUM");
+            wheelslip.sandCoefPortId = FullPortId(sander, "SAND_COEF");
+            wheelslip.engineBrakingActivePortId = FullPortId(fluidCoupler, "HYDRO_DYNAMIC_BRAKE_EFFECT");
+
+            var fusebox = CreateSimComponent<IndependentFusesDefinitionProxy>("fusebox");
+            fusebox.fuses = new[]
+            {
+                new FuseDefinition("ELECTRONICS_MAIN", false),
+                new FuseDefinition("ENGINE_STARTER", false)
+            };
+
+            ApplyMethodToAll<IDH4Defaults>(s => s.ApplyDH4Defaults());
+        }
+    }
+}

--- a/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
@@ -22,6 +22,7 @@ namespace CCL.Creator.Wizards.SimSetup
 
         public override void CreateSimForBasisImpl(int basisIndex)
         {
+            // Simulation components.
             var throttle = CreateOverridableControl(OverridableControlType.Throttle);
             var thrtPowr = CreateSimComponent<ThrottleGammaPowerConversionDefinitionProxy>("throttlePower");
             var reverser = CreateReverserControl();
@@ -50,7 +51,7 @@ namespace CCL.Creator.Wizards.SimSetup
             var sander = CreateSanderControl();
 
             var engine = CreateSimComponent<DieselEngineDirectDefinitionProxy>("de");
-            var engineOff = CreateSibling<OverridableControlProxy>(engine);
+            var engineOff = CreateSibling<PowerOffControlProxy>(engine);
             engineOff.portId = FullPortId(engine, "EMERGENCY_ENGINE_OFF_EXT_IN");
             var engineOn = CreateSibling<EngineOnReaderProxy>(engine);
             engineOn.portId = FullPortId(engine, "ENGINE_ON");
@@ -102,6 +103,7 @@ namespace CCL.Creator.Wizards.SimSetup
             directWheelslip.engineRpmMaxPortId = FullPortId(engine, "RPM");
             directWheelslip.gearRatioPortId = FullPortId(fluidCoupler, "GEAR_RATIO");
 
+            // Fusebox and fuse connections.
             var fusebox = CreateSimComponent<IndependentFusesDefinitionProxy>("fusebox");
             fusebox.fuses = new[]
             {
@@ -115,6 +117,7 @@ namespace CCL.Creator.Wizards.SimSetup
             engine.engineStarterFuseId = FullPortId(fusebox, "ENGINE_STARTER");
             autoCooler.powerFuseId = FullPortId(fusebox, "ELECTRONICS_MAIN");
 
+            // Damage.
             _damageController.mechanicalPTDamagerPortIds = new[]
             {
                 FullPortId(engine, "GENERATED_ENGINE_DAMAGE"),
@@ -127,8 +130,10 @@ namespace CCL.Creator.Wizards.SimSetup
             };
             _damageController.mechanicalPTOffExternalInPortIds = new[] { FullPortId(engine, "COLLISION_ENGINE_OFF_EXT_IN") };
 
+            // Port connections.
             ConnectPorts(fluidCoupler, "OUTPUT_SHAFT_TORQUE", traction, "TORQUE_IN");
 
+            // Port reference connections.
             ConnectPortRef(genericHornControl, "CONTROL", horn, "HORN_CONTROL");
             ConnectPortRef(bellControl, "EXT_IN", bell, "CONTROL");
 
@@ -165,8 +170,10 @@ namespace CCL.Creator.Wizards.SimSetup
             ConnectPortRef(cooler, "HEAT_OUT", cooler, "HEAT_IN_2");
             ConnectPortRef(autoCooler, "HEAT_OUT", cooler, "HEAT_IN_3");
 
+            // Apply defaults.
             ApplyMethodToAll<IDH4Defaults>(s => s.ApplyDH4Defaults());
 
+            // Control blockers.
             AddControlBlocker(throttle, dynBrake, "EXT_IN", 0, BlockType.BLOCK_ON_ABOVE_THRESHOLD)
                 .blockedControlPortId = FullPortId(throttle, "EXT_IN");
 

--- a/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
@@ -82,10 +82,10 @@ namespace CCL.Creator.Wizards.SimSetup
             cooler.transform.parent = fluidCoupler.transform;
             var autoCooler = CreateSimComponent<AutomaticCoolerDefinitionProxy>("fcAutomaticCooler");
             autoCooler.transform.parent = fluidCoupler.transform;
-            var heat = CreateSimComponent<HeatReservoirDefinitionProxy>("coolant");
-            heat.transform.parent = fluidCoupler.transform;
-            heat.inputCount = 4;
-            heat.OnValidate();
+            var coolant = CreateSimComponent<HeatReservoirDefinitionProxy>("coolant");
+            coolant.transform.parent = fluidCoupler.transform;
+            coolant.inputCount = 4;
+            coolant.OnValidate();
 
             var poweredAxles = CreateSimComponent<ConstantPortDefinitionProxy>("poweredAxles");
             poweredAxles.value = 4;
@@ -128,6 +128,42 @@ namespace CCL.Creator.Wizards.SimSetup
             _damageController.mechanicalPTOffExternalInPortIds = new[] { FullPortId(engine, "COLLISION_ENGINE_OFF_EXT_IN") };
 
             ConnectPorts(fluidCoupler, "OUTPUT_SHAFT_TORQUE", traction, "TORQUE_IN");
+
+            ConnectPortRef(genericHornControl, "CONTROL", horn, "HORN_CONTROL");
+            ConnectPortRef(bellControl, "EXT_IN", bell, "CONTROL");
+
+            ConnectPortRef(sand, "AMOUNT", sander, "SAND");
+            ConnectPortRef(sand, "CONSUME_EXT_IN", sander, "SAND_CONSUMPTION");
+
+            ConnectPortRef(throttle, "EXT_IN", engine, "THROTTLE");
+            ConnectPortRef(fluidCoupler, "TURBINE_RPM", engine, "DRIVEN_RPM");
+            ConnectPortRef(fuel, "AMOUNT", engine, "FUEL");
+            ConnectPortRef(fuel, "CONSUME_EXT_IN", engine, "FUEL_CONSUMPTION");
+            ConnectPortRef(oil, "AMOUNT", engine, "OIL");
+            ConnectPortRef(oil, "CONSUME_EXT_IN", engine, "OIL_CONSUMPTION");
+            ConnectPortRef(loadTorque, "LOAD_TORQUE_TOTAL", engine, "LOAD_TORQUE");
+            ConnectPortRef(coolant, "TEMPERATURE", engine, "TEMPERATURE");
+
+            ConnectPortRef(engine, "RPM_NORMALIZED", compressor, "ENGINE_RPM_NORMALIZED");
+
+            ConnectPortRef(dynBrake, "EXT_IN", fluidCoupler, "HYDRODYNAMIC_BRAKE");
+            ConnectPortRef(reverser, "REVERSER", fluidCoupler, "REVERSER");
+            ConnectPortRef(engine, "RPM", fluidCoupler, "INPUT_SHAFT_RPM");
+            ConnectPortRef(engine, "MAX_RPM", fluidCoupler, "MAX_RPM");
+            ConnectPortRef(traction, "WHEEL_RPM_EXT_IN", fluidCoupler, "OUTPUT_SHAFT_RPM");
+            ConnectPortRef(coolant, "TEMPERATURE", fluidCoupler, "TEMPERATURE");
+
+            ConnectPortRef(coolant, "TEMPERATURE", cooler, "TEMPERATURE");
+            ConnectPortRef(engine, "ENGINE_ON", autoCooler, "IS_POWERED");
+            ConnectPortRef(coolant, "TEMPERATURE", autoCooler, "TEMPERATURE");
+
+            ConnectPortRef(compressor, "LOAD_TORQUE", loadTorque, "LOAD_TORQUE_0");
+            ConnectPortRef(fluidCoupler, "INPUT_SHAFT_TORQUE", loadTorque, "LOAD_TORQUE_1");
+
+            ConnectPortRef(engine, "HEAT_OUT", cooler, "HEAT_IN_0");
+            ConnectPortRef(fluidCoupler, "HEAT_OUT", cooler, "HEAT_IN_1");
+            ConnectPortRef(cooler, "HEAT_OUT", cooler, "HEAT_IN_2");
+            ConnectPortRef(autoCooler, "HEAT_OUT", cooler, "HEAT_IN_3");
 
             ApplyMethodToAll<IDH4Defaults>(s => s.ApplyDH4Defaults());
 

--- a/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
+++ b/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
@@ -284,13 +284,19 @@ namespace CCL.Creator.Wizards.SimSetup
             return control;
         }
 
-        protected OverridableControlProxy AddControlBlocker(ExternalControlDefinitionProxy control, SimComponentDefinitionProxy blocking, string port, float threshold,
+        protected ControlBlockerProxy AddControlBlocker(ExternalControlDefinitionProxy control, SimComponentDefinitionProxy blocking, string port, float threshold,
             ControlBlockerProxy.BlockerDefinition.BlockType blockerType)
         {
             return AddControlBlocker(control.GetComponent<OverridableControlProxy>(), blocking, port, threshold, blockerType);
         }
 
-        protected OverridableControlProxy AddControlBlocker(OverridableControlProxy control, SimComponentDefinitionProxy blocking, string port, float threshold,
+        protected ControlBlockerProxy AddControlBlocker(ReverserDefinitionProxy reverser, SimComponentDefinitionProxy blocking, string port, float threshold,
+            ControlBlockerProxy.BlockerDefinition.BlockType blockerType)
+        {
+            return AddControlBlocker(reverser.GetComponent<OverridableControlProxy>(), blocking, port, threshold, blockerType);
+        }
+
+        protected ControlBlockerProxy AddControlBlocker(OverridableControlProxy control, SimComponentDefinitionProxy blocking, string port, float threshold,
             ControlBlockerProxy.BlockerDefinition.BlockType blockerType)
         {
             control.OnValidate();
@@ -311,7 +317,7 @@ namespace CCL.Creator.Wizards.SimSetup
 
             control.controlBlocker.blockers = blockers.ToArray();
 
-            return control;
+            return control.controlBlocker;
         }
 
         protected CompressorSimControllerProxy CreateCompressorSim(SimComponentDefinitionProxy compressor)

--- a/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
+++ b/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
@@ -18,6 +18,7 @@ namespace CCL.Creator.Wizards.SimSetup
         {
             DieselMechanical,
             DieselElectric,
+            DieselHydraulic,
             BatteryElectric,
             Slug,
             Steam,
@@ -59,6 +60,7 @@ namespace CCL.Creator.Wizards.SimSetup
                     {
                         SimulationType.DieselMechanical => new DieselMechSimCreator(_targetRoot),
                         SimulationType.DieselElectric => new DieselElectricSimCreator(_targetRoot),
+                        SimulationType.DieselHydraulic => new DieselHydraulicSimCreator(_targetRoot),
                         SimulationType.BatteryElectric => new BatteryElectricSimCreator(_targetRoot),
                         SimulationType.Slug => new SlugSimCreator(_targetRoot),
                         SimulationType.Steam => new SteamerSimCreator(_targetRoot),

--- a/CCL.Importer/Patches/StationLocoSpawnerPatches.cs
+++ b/CCL.Importer/Patches/StationLocoSpawnerPatches.cs
@@ -24,7 +24,7 @@ namespace CCL.Importer.Patches
                         // If the group is supposed to use this spawner...
                         if (group.Track.ToName() == __instance.name)
                         {
-                            CCLPlugin.Log($"Injecting loco spawn group [{variant.id}, {string.Join(", ", group.Liveries)}]");
+                            CCLPlugin.Log($"Injecting loco spawn group [{variant.id}, {string.Join(", ", group.AdditionalLiveries)}]");
                             __instance.locoTypeGroupsToSpawn.Add(FromGroup(variant, group));
                         }
                     }
@@ -87,7 +87,7 @@ namespace CCL.Importer.Patches
         {
             List<TrainCarLivery> variants = new() { variant };
 
-            foreach (var item in group.Liveries)
+            foreach (var item in group.AdditionalLiveries)
             {
                 if (DV.Globals.G.Types.TryGetLivery(item, out TrainCarLivery livery))
                 {

--- a/CCL.Importer/Proxies/Controllers/MiscControllerReplacer.cs
+++ b/CCL.Importer/Proxies/Controllers/MiscControllerReplacer.cs
@@ -53,6 +53,8 @@ namespace CCL.Importer.Proxies.Controllers
             CreateMap<BoilerSimControllerProxy, BoilerSimController>().AutoCacheAndMap();
 
             CreateMap<WindowsBreakingControllerProxy, WindowsBreakingController>().AutoCacheAndMap();
+
+            CreateMap<ClapperControllerProxy, ClapperController>().AutoCacheAndMap();
         }
 
         private void DeadTractionMotorsControllerAfter(DeadTractionMotorsControllerProxy _, DeadTractionMotorsController controller)

--- a/CCL.Importer/Proxies/Controls/OverridableControlReplacer.cs
+++ b/CCL.Importer/Proxies/Controls/OverridableControlReplacer.cs
@@ -25,7 +25,8 @@ namespace CCL.Importer.Proxies.Controls
             CachedBlocker(CreateMap<OverridableControlProxy, HeadlightsControlFront>().AutoCacheAndMap(s => s.ControlType == OverridableControlType.HeadlightsFront));
             CachedBlocker(CreateMap<OverridableControlProxy, HeadlightsControlRear>().AutoCacheAndMap(s => s.ControlType == OverridableControlType.HeadlightsRear));
             CachedBlocker(CreateMap<OverridableControlProxy, DynamicBrakeControl>().AutoCacheAndMap(s => s.ControlType == OverridableControlType.DynamicBrake));
-            CachedBlocker(CreateMap<OverridableControlProxy, PowerOffControl>().AutoCacheAndMap(s => s.ControlType == OverridableControlType.FuelCutoff));
+            //CreateMap<OverridableControlProxy, PowerOffControl>().AutoCacheAndMap(s => s.ControlType == OverridableControlType.FuelCutoff);
+            CreateMap<PowerOffControlProxy, PowerOffControl>().AutoCacheAndMap().ForMember(d => d.controlBlocker, o => o.MapFrom(s => s.controlBlocker));
 
             CreateMap<InteriorControlsManagerProxy, InteriorControlsManager>().AutoCacheAndMap();
             CreateMap<BaseControlsOverriderProxy, BaseControlsOverrider>().AutoCacheAndMap();

--- a/CCL.Importer/Proxies/Controls/OverridableControlReplacer.cs
+++ b/CCL.Importer/Proxies/Controls/OverridableControlReplacer.cs
@@ -3,8 +3,6 @@ using CCL.Types.Proxies.Controls;
 using DV.HUD;
 using DV.Simulation.Cars;
 using DV.Simulation.Controllers;
-using System;
-using UnityEngine;
 
 namespace CCL.Importer.Proxies.Controls
 {
@@ -13,6 +11,7 @@ namespace CCL.Importer.Proxies.Controls
         public OverridableControlReplacer()
         {
             CreateMap<ControlBlockerProxy, ControlBlocker>().AutoCacheAndMap();
+            CreateMap<ControlBlockerProxy.BlockerDefinition, ControlBlocker.BlockerDefinition>();
 
             CachedBlocker(CreateMap<OverridableControlProxy, ThrottleControl>().AutoCacheAndMap(s => s.ControlType == OverridableControlType.Throttle));
             CachedBlocker(CreateMap<OverridableControlProxy, BrakeControl>().AutoCacheAndMap(s => s.ControlType == OverridableControlType.TrainBrake));
@@ -37,7 +36,7 @@ namespace CCL.Importer.Proxies.Controls
             where TSource : OverridableControlProxy
             where TDestination : OverridableBaseControl
         {
-            return cfg.ForMember(d => d.controlBlocker, o => o.MapFrom(s => s.controlBlocker));
+            return cfg.ForMember(d => d.controlBlocker, o => o.MapFrom(s => Mapper.GetFromCache(s.controlBlocker)));
         }
     }
 }

--- a/CCL.Importer/Proxies/Indicators/IndicatorProxyMapper.cs
+++ b/CCL.Importer/Proxies/Indicators/IndicatorProxyMapper.cs
@@ -19,7 +19,8 @@ namespace CCL.Importer.Proxies.Indicators
 
             CreateMap<IndicatorEmissionProxy, IndicatorEmission>().AutoCacheAndMap();
             CreateMap<IndicatorGaugeProxy, IndicatorGauge>().AutoCacheAndMap();
-            CreateMap<IndicatorGaugeLaggingProxy, IndicatorGaugeLagging>().AutoCacheAndMap();
+            CreateMap<IndicatorGaugeLaggingProxy, IndicatorGaugeLagging>().AutoCacheAndMap()
+                .AfterMap(IndicatorGaugeLaggingAfter);
             CreateMap<IndicatorModelChangerProxy, IndicatorModelChanger>().AutoCacheAndMap();
             CreateMap<IndicatorScalerProxy, IndicatorScaler>().AutoCacheAndMap();
             CreateMap<IndicatorSliderProxy, IndicatorSlider>().AutoCacheAndMap();
@@ -31,6 +32,20 @@ namespace CCL.Importer.Proxies.Indicators
                 .WithCachedMember(d => d.lampInd);
 
             CreateMap<LabelLocalizer, Localize>();
+        }
+
+        private void IndicatorGaugeLaggingAfter(IndicatorGaugeLaggingProxy src, IndicatorGaugeLagging dest)
+        {
+            // Prevent disabling the component, as it is getting mapped twice for some reason.
+            // At least until a better solution is found.
+            if (src.EnabledState != null)
+            {
+                dest.enabled = src.EnabledState.Value;
+            }
+            else
+            {
+                src.EnabledState = src.enabled;
+            }
         }
     }
 }

--- a/CCL.Importer/Proxies/Simulation/SimulationReplacer.cs
+++ b/CCL.Importer/Proxies/Simulation/SimulationReplacer.cs
@@ -17,6 +17,7 @@ namespace CCL.Importer.Proxies.Simulation
 
             // heat
             CreateMap<PassiveCoolerDefinitionProxy, PassiveCoolerDefinition>().AutoCacheAndMap();
+            CreateMap<AutomaticCoolerDefinitionProxy, AutomaticCoolerDefinition>().AutoCacheAndMap();
             CreateMap<DirectionalCoolerDefinitionProxy, DirectionalMovementCoolerDefinition>().AutoCacheAndMap();
             CreateMap<HeatReservoirDefinitionProxy, HeatReservoirDefinition>().AutoCacheAndMap();
 

--- a/CCL.Importer/Proxies/Wheels/WheelProxyReplacer.cs
+++ b/CCL.Importer/Proxies/Wheels/WheelProxyReplacer.cs
@@ -28,6 +28,8 @@ namespace CCL.Importer.Proxies.Wheels
             CreateMap<WheelslipSparksControllerProxy, WheelslipSparksController>().AutoCacheAndMap();
             CreateMap<WheelslipSparksControllerProxy.WheelSparksDefinition, WheelslipSparksController.WheelSparksDefinition>()
                 .ForMember(d => d.poweredWheel, o => o.MapFrom(s => Mapper.GetFromCache(s.poweredWheel)));
+
+            CreateMap<DirectDriveMaxWheelslipRpmCalculatorProxy, DirectDriveMaxWheelslipRpmCalculator>().AutoCacheAndMap();
         }
 
         private void PoweredWheelsManagerProxyAfter(PoweredWheelsManagerProxy proxy, PoweredWheelsManager real)

--- a/CCL.Types/Components/CopyVanillaAudioSystem.cs
+++ b/CCL.Types/Components/CopyVanillaAudioSystem.cs
@@ -40,7 +40,7 @@ namespace CCL.Types.Components
 
         [InspectorName("")]
         SeparatorDE2 = 999,
-        DE2Engine,
+        DE2Engine = 1000,
         DE2EnginePiston,
         DE2EngineIgnition,
         DE2ElectricMotor,
@@ -49,7 +49,7 @@ namespace CCL.Types.Components
 
         [InspectorName("")]
         SeparatorDE6 = 1049,
-        DE6EngineIdle,
+        DE6EngineIdle = 1050,
         DE6EngineThrottling,
         DE6EngineIgnition,
         DE6ElectricMotor,
@@ -60,7 +60,7 @@ namespace CCL.Types.Components
 
         [InspectorName("")]
         SeparatorDH4 = 1099,
-        DH4Engine,
+        DH4Engine = 1100,
         DH4EnginePiston,
         DH4EngineIgnition,
         DH4FluidCoupler,
@@ -73,7 +73,7 @@ namespace CCL.Types.Components
 
         [InspectorName("")]
         SeparatorDM3 = 1149,
-        DM3Engine,
+        DM3Engine = 1150,
         DM3EnginePiston,
         DM3EngineIgnition,
         DM3JakeBrake,
@@ -82,8 +82,8 @@ namespace CCL.Types.Components
         DM3Compressor,
 
         [InspectorName("")]
-        SeparatorSteam = 1999,
-        SteamerCoalDump,
+        SeparatorSteam = 2999,
+        SteamerCoalDump = 3000,
         SteamerFire,
         SteamerFireboxWind,
         SteamerSafetyRelease,
@@ -100,12 +100,12 @@ namespace CCL.Types.Components
         SteamerBellRing,
         SteamerBellPump,
 
-        S060Whistle = 2050,
-        S282Whistle = 2100,
+        S060Whistle = 3050,
+        S282Whistle = 3100,
 
         [InspectorName("")]
-        SeparatorBE2 = 2999,
-        BE2ElectricMotor,
+        SeparatorBE2 = 4999,
+        BE2ElectricMotor = 5000,
         [InspectorName("BE2 TM Controller")]
         BE2TMController,
         BE2Compressor,

--- a/CCL.Types/LocoSpawnGroup.cs
+++ b/CCL.Types/LocoSpawnGroup.cs
@@ -70,14 +70,14 @@ namespace CCL.Types
         [Tooltip("The track where the loco(s) will spawn")]
         public SpawnTrack Track;
         [Tooltip("Extra locos/tenders to spawn together (in order)")]
-        public string[] Liveries;
+        public string[] AdditionalLiveries;
 
         public LocoSpawnGroup() : this(SpawnTrack.MachineFactoryA1, new string[0]) { }
 
         public LocoSpawnGroup(SpawnTrack track, string[] liveries)
         {
             Track = track;
-            Liveries = liveries;
+            AdditionalLiveries = liveries;
         }
     }
 

--- a/CCL.Types/Proxies/Controllers/ClapperControllerProxy.cs
+++ b/CCL.Types/Proxies/Controllers/ClapperControllerProxy.cs
@@ -1,0 +1,16 @@
+﻿using CCL.Types.Proxies.Ports;
+using UnityEngine;
+
+namespace CCL.Types.Proxies.Controllers
+{
+    public class ClapperControllerProxy : MonoBehaviour
+    {
+        public Transform clapperTransform;
+        [PortId(DVPortValueType.RPM, true)]
+        public string engineRpmNormalizedPortId;
+        [PortId(DVPortValueType.STATE, true)]
+        public string engineOnPortId;
+        public float highestMaxAngleAtPercentage = 0.33f;
+        public float highestMinAngleAtPercentage = 0.66f;
+    }
+}

--- a/CCL.Types/Proxies/Controls/DVControlType.cs
+++ b/CCL.Types/Proxies/Controls/DVControlType.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CCL.Types.Proxies.Controls
+﻿namespace CCL.Types.Proxies.Controls
 {
     public enum DVControlClass
     {
@@ -29,7 +23,7 @@ namespace CCL.Types.Proxies.Controls
         HeadlightsFront = DVControlType.HeadlightsFront,
         HeadlightsRear = DVControlType.HeadlightsRear,
         DynamicBrake = DVControlType.DynamicBrake,
-        FuelCutoff = DVControlType.FuelCutoff,
+        //FuelCutoff = DVControlType.FuelCutoff,
     }
 
     public enum DVControlType

--- a/CCL.Types/Proxies/Controls/ExternalControlDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Controls/ExternalControlDefinitionProxy.cs
@@ -1,9 +1,5 @@
 ﻿using CCL.Types.Proxies.Ports;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CCL.Types.Proxies.Controls
 {

--- a/CCL.Types/Proxies/Controls/OverridableControlProxy.cs
+++ b/CCL.Types/Proxies/Controls/OverridableControlProxy.cs
@@ -30,9 +30,31 @@ namespace CCL.Types.Proxies.Controls
     {
         [PortId(DVPortType.EXTERNAL_IN, DVPortValueType.CONTROL, true)]
         public string portId;
-        public bool neutralAt0;
         [Header("optional")]
         public ControlBlockerProxy controlBlocker;
+        public bool neutralAt0;
+
+        public IEnumerable<PortIdField> ExposedPortIdFields => new[]
+        {
+            new PortIdField(this, nameof(portId), portId, DVPortType.EXTERNAL_IN, DVPortValueType.CONTROL)
+        };
+
+        public void OnValidate()
+        {
+            if (controlBlocker == null)
+            {
+                controlBlocker = GetComponent<ControlBlockerProxy>();
+            }
+        }
+    }
+
+    public class PowerOffControlProxy : MonoBehaviour, IHasPortIdFields
+    {
+        [PortId(DVPortType.EXTERNAL_IN, DVPortValueType.CONTROL, true)]
+        public string portId;
+        [Header("optional")]
+        public ControlBlockerProxy controlBlocker;
+        public bool signalClearedBySim;
 
         public IEnumerable<PortIdField> ExposedPortIdFields => new[]
         {

--- a/CCL.Types/Proxies/Indicators/IndicatorGaugeProxy.cs
+++ b/CCL.Types/Proxies/Indicators/IndicatorGaugeProxy.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace CCL.Types.Proxies.Indicators
 {
@@ -10,7 +11,6 @@ namespace CCL.Types.Proxies.Indicators
         public bool unclamped;
         public Vector3 rotationAxis = Vector3.forward;
         public float gizmoRadius = 0.1f;
-
 
         protected const float GIZMO_RADIUS = 0.1f;
         protected const int GIZMO_SEGMENTS = 20;
@@ -55,5 +55,8 @@ namespace CCL.Types.Proxies.Indicators
     public class IndicatorGaugeLaggingProxy : IndicatorGaugeProxy
     {
         public float smoothTime = 0.5f;
+
+        [NonSerialized]
+        public bool? EnabledState = null;
     }
 }

--- a/CCL.Types/Proxies/Indicators/IndicatorProxy.cs
+++ b/CCL.Types/Proxies/Indicators/IndicatorProxy.cs
@@ -6,5 +6,8 @@ namespace CCL.Types.Proxies.Indicators
     {
         public float minValue;
         public float maxValue = 1f;
+
+        // To show the enable/disable checkbox.
+        public void Start() { }
     }
 }

--- a/CCL.Types/Proxies/Indicators/IndicatorProxy.cs
+++ b/CCL.Types/Proxies/Indicators/IndicatorProxy.cs
@@ -6,8 +6,5 @@ namespace CCL.Types.Proxies.Indicators
     {
         public float minValue;
         public float maxValue = 1f;
-
-        // To show the enable/disable checkbox.
-        public void Start() { }
     }
 }

--- a/CCL.Types/Proxies/Simulation/AutomaticCoolerDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/AutomaticCoolerDefinitionProxy.cs
@@ -1,0 +1,44 @@
+﻿using CCL.Types.Proxies.Ports;
+using System.Collections.Generic;
+
+namespace CCL.Types.Proxies.Simulation
+{
+    public class AutomaticCoolerDefinitionProxy : SimComponentDefinitionProxy, IHasFuseIdFields, IDH4Defaults
+    {
+        public float coolingRate = 12500f;
+        public float activationTemperature = 100f;
+        public float deactivationTemperature = 90f;
+        public float easeTime = 2f;
+
+        [FuseId]
+        public string powerFuseId;
+
+
+        public override IEnumerable<PortDefinition> ExposedPorts => new[]
+        {
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.HEAT_RATE, "HEAT_OUT"),
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.STATE, "COOLING_EFFECT")
+        };
+
+        public override IEnumerable<PortReferenceDefinition> ExposedPortReferences => new[]
+        {
+            new PortReferenceDefinition(DVPortValueType.STATE, "IS_POWERED"),
+            new PortReferenceDefinition(DVPortValueType.TEMPERATURE, "TEMPERATURE"),
+            new PortReferenceDefinition(DVPortValueType.TEMPERATURE, "TARGET_TEMPERATURE")
+        };
+
+        public IEnumerable<FuseIdField> ExposedFuseIdFields => new[] { new FuseIdField(this, nameof(powerFuseId), powerFuseId) };
+
+        #region Defaults
+
+        public void ApplyDH4Defaults()
+        {
+            coolingRate = 8000.0f;
+            activationTemperature = 85.0f;
+            deactivationTemperature = 75.0f;
+            easeTime = 0.8f;
+        }
+
+        #endregion
+    }
+}

--- a/CCL.Types/Proxies/Simulation/Diesel/DieselEngineDirectDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/Diesel/DieselEngineDirectDefinitionProxy.cs
@@ -159,6 +159,42 @@ namespace CCL.Types.Proxies.Simulation.Diesel
             rpmDamageImmunityTime = 2.0f;
             overheatingThreshold = 110.0f;
             overheatingDamagePerDegreePerSecond = 0.1f;
+
+            rpmToPowerCurve = new AnimationCurve()
+            {
+                preWrapMode = WrapMode.Loop,
+                postWrapMode = WrapMode.Loop,
+                keys = new[]
+{
+                    new Keyframe
+                    {
+                        time = 0.0f,
+                        value = 0.0f,
+                        inTangent = 842.26666f,
+                        outTangent = 842.26666f,
+                        inWeight = 1 / 3f,
+                        outWeight = 0.031815805f,
+                    },
+                    new Keyframe
+                    {
+                        time = 1500.0f,
+                        value = 1000000.0f,
+                        inTangent = 0.000969854f,
+                        outTangent = 0.000969854f,
+                        inWeight = 1 / 3f,
+                        outWeight = 1.0f,
+                    },
+                    new Keyframe
+                    {
+                        time = 1600.0f,
+                        value = 0.0f,
+                        inTangent = -27790.76f,
+                        outTangent = -27790.76f,
+                        inWeight = 0.062794186f,
+                        outWeight = 1 / 3f,
+                    }
+                }
+            };
         }
 
         public void ApplyDE2Defaults()
@@ -178,6 +214,51 @@ namespace CCL.Types.Proxies.Simulation.Diesel
             rpmDamageImmunityTime = 2.0f;
             overheatingThreshold = 110.0f;
             overheatingDamagePerDegreePerSecond = 0.1f;
+
+            rpmToPowerCurve = new AnimationCurve()
+            {
+                preWrapMode = WrapMode.Loop,
+                postWrapMode = WrapMode.Loop,
+                keys = new[]
+    {
+                    new Keyframe
+                    {
+                        time = 0.0f,
+                        value = 0.0f,
+                        inTangent = 0.0f,
+                        outTangent = 0.0f,
+                        inWeight = 1 / 3f,
+                        outWeight = 1 / 3f,
+                    },
+                    new Keyframe
+                    {
+                        time = 600.0f,
+                        value = 100000.0f,
+                        inTangent = 2000 / 9f,
+                        outTangent = 2000 / 9f,
+                        inWeight = 1 / 3f,
+                        outWeight = 1 / 3f,
+                    },
+                    new Keyframe
+                    {
+                        time = 1800.0f,
+                        value = 400000.0f,
+                        inTangent = 0.0f,
+                        outTangent = 0.0f,
+                        inWeight = 1 / 3f,
+                        outWeight = 1 / 3f,
+                    },
+                    new Keyframe
+                    {
+                        time = 2000.0f,
+                        value = 0.0f,
+                        inTangent = -4306.064f,
+                        outTangent = -4306.064f,
+                        inWeight = 1 / 3f,
+                        outWeight = 1 / 3f,
+                    }
+                }
+            };
         }
 
         public void ApplyDE6Defaults()
@@ -197,6 +278,51 @@ namespace CCL.Types.Proxies.Simulation.Diesel
             rpmDamageImmunityTime = 2.0f;
             overheatingThreshold = 110.0f;
             overheatingDamagePerDegreePerSecond = 0.1f;
+
+            rpmToPowerCurve = new AnimationCurve()
+            {
+                preWrapMode = WrapMode.Loop,
+                postWrapMode = WrapMode.Loop,
+                keys = new[]
+{
+                    new Keyframe
+                    {
+                        time = 0.0f,
+                        value = 0.0f,
+                        inTangent = 1440.5848f,
+                        outTangent = 1440.5848f,
+                        inWeight = 1 / 3f,
+                        outWeight = 0.10329206f,
+                    },
+                    new Keyframe
+                    {
+                        time = 275.0f,
+                        value = 300000.0f,
+                        inTangent = 1494.04f,
+                        outTangent = 1494.04f,
+                        inWeight = 1 / 3f,
+                        outWeight = 0.04434629f,
+                    },
+                    new Keyframe
+                    {
+                        time = 900.0f,
+                        value = 1700000.0f,
+                        inTangent = 0.0f,
+                        outTangent = 0.0f,
+                        inWeight = 1 / 3f,
+                        outWeight = 1 / 3f,
+                    },
+                    new Keyframe
+                    {
+                        time = 950.0f,
+                        value = 0.0f,
+                        inTangent = -68105.2f,
+                        outTangent = -68105.2f,
+                        inWeight = 0.035001222f,
+                        outWeight = 1 / 3f,
+                    }
+                }
+            };
         }
 
         #endregion

--- a/CCL.Types/Proxies/Simulation/Diesel/DieselEngineDirectDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/Diesel/DieselEngineDirectDefinitionProxy.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace CCL.Types.Proxies.Simulation.Diesel
 {
-    public class DieselEngineDirectDefinitionProxy : SimComponentDefinitionProxy, IHasFuseIdFields, IDM3Defaults, IDE2Defaults, IDE6Defaults
+    public class DieselEngineDirectDefinitionProxy : SimComponentDefinitionProxy, IHasFuseIdFields, IDM3Defaults, IDH4Defaults, IDE2Defaults, IDE6Defaults
     {
         [Header("RPM Range")]
         public float rotationalInertia;
@@ -140,6 +140,25 @@ namespace CCL.Types.Proxies.Simulation.Diesel
                     }
                 }
             };
+        }
+
+        public void ApplyDH4Defaults()
+        {
+            rotationalInertia = 10.0f;
+            viscousDampingFactor = 40.0f;
+            engineRpmMax = 1600.0f;
+            engineRpmIdle = 600.0f;
+
+            retarderBrakingTorque = 100000.0f;
+
+            fuelInjection = 2.0f;
+            oilConsumptionRate = 0.025f;
+
+            noOilDamagePerSecond = 30.0f;
+            rpmDamagePerSecond = 0.01f;
+            rpmDamageImmunityTime = 2.0f;
+            overheatingThreshold = 110.0f;
+            overheatingDamagePerDegreePerSecond = 0.1f;
         }
 
         public void ApplyDE2Defaults()

--- a/CCL.Types/Proxies/Simulation/Diesel/HydraulicTransmissionDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/Diesel/HydraulicTransmissionDefinitionProxy.cs
@@ -71,11 +71,6 @@ namespace CCL.Types.Proxies.Simulation.Diesel
 
         #region Defaults
 
-        [MethodButton(nameof(ApplyDM3Defaults), "Apply DM3 Defaults")]
-        [MethodButton(nameof(ApplyDH4Defaults), "Apply DH4 Defaults")]
-        [RenderMethodButtons]
-        public bool renderButtons;
-
         public void ApplyDM3Defaults()
         {
             outputTorqueLimit = 25000;

--- a/CCL.Types/Proxies/Simulation/PassiveCoolerDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/PassiveCoolerDefinitionProxy.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace CCL.Types.Proxies.Simulation
 {
-    public class PassiveCoolerDefinitionProxy : SimComponentDefinitionProxy, IDE2Defaults, IDE6Defaults, IBE2Defaults
+    public class PassiveCoolerDefinitionProxy : SimComponentDefinitionProxy, IDH4Defaults, IDE2Defaults, IDE6Defaults, IBE2Defaults
     {
         public float coolingRate = 12500f;
 
@@ -19,6 +19,11 @@ namespace CCL.Types.Proxies.Simulation
         };
 
         #region Defaults
+
+        public void ApplyDH4Defaults()
+        {
+            coolingRate = 3750.0f;
+        }
 
         public void ApplyDE2Defaults()
         {

--- a/CCL.Types/Proxies/Wheels/DirectDriveMaxWheelslipRpmCalculatorProxy.cs
+++ b/CCL.Types/Proxies/Wheels/DirectDriveMaxWheelslipRpmCalculatorProxy.cs
@@ -1,0 +1,20 @@
+﻿using CCL.Types.Proxies.Ports;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types.Proxies.Wheels
+{
+    public class DirectDriveMaxWheelslipRpmCalculatorProxy : MonoBehaviour, IHasPortIdFields
+    {
+        [PortId(DVPortValueType.RPM, false)]
+        public string engineRpmMaxPortId;
+        [PortId(DVPortValueType.GENERIC, false)]
+        public string gearRatioPortId;
+
+        public IEnumerable<PortIdField> ExposedPortIdFields => new[]
+        {
+            new PortIdField(this, nameof(engineRpmMaxPortId), engineRpmMaxPortId, DVPortValueType.RPM),
+            new PortIdField(this, nameof(gearRatioPortId), gearRatioPortId, DVPortValueType.GENERIC),
+        };
+    }
+}


### PR DESCRIPTION
Adds diesel-hydraulic simulation components.
Changed power off control to be a separate component.
Tweaked importing of IndicatorGauges to prevent the Lagging version from always disabling itself.
Adds clapper controller.
Adds missing parts to other wizards.
* Horns, bells and control blockers
* Default power curves