### PR TITLE
Resource Explosion, Animation Port Readers, Wipers

### DIFF
--- a/CCL.Creator/Wizards/SimSetup/BatteryElectricSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/BatteryElectricSimCreator.cs
@@ -67,7 +67,7 @@ namespace CCL.Creator.Wizards.SimSetup
             var tmExplosion = CreateSibling<ExplosionActivationOnSignalProxy>(tm);
             tmExplosion.explosionSignalPortId = FullPortId(tm, "OVERSPEED_EXPLOSION_TRIGGER");
             tmExplosion.bodyDamagePercentage = 0.05f;
-            tmExplosion.explosion = ExplosionPrefab.ExplosionTMOverspeed;
+            tmExplosion.explosion = ExplosionPrefab.TMOverspeed;
 
             var cooler = CreateSimComponent<PassiveCoolerDefinitionProxy>("tmPassiveCooler");
             cooler.transform.parent = tm.transform;

--- a/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
@@ -94,7 +94,7 @@ namespace CCL.Creator.Wizards.SimSetup
             var tmExplosion = CreateSibling<ExplosionActivationOnSignalProxy>(tm);
             tmExplosion.explosionSignalPortId = FullPortId(tm, "OVERSPEED_EXPLOSION_TRIGGER");
             tmExplosion.bodyDamagePercentage = 0.05f;
-            tmExplosion.explosion = ExplosionPrefab.ExplosionTMOverspeed;
+            tmExplosion.explosion = ExplosionPrefab.TMOverspeed;
 
             var cooler = CreateSimComponent<PassiveCoolerDefinitionProxy>("tmPassiveCooler");
             cooler.transform.parent = tm.transform;

--- a/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
@@ -165,10 +165,10 @@ namespace CCL.Creator.Wizards.SimSetup
             ConnectPortRef(compressor, "LOAD_TORQUE", loadTorque, "LOAD_TORQUE_0");
             ConnectPortRef(fluidCoupler, "INPUT_SHAFT_TORQUE", loadTorque, "LOAD_TORQUE_1");
 
-            ConnectPortRef(engine, "HEAT_OUT", cooler, "HEAT_IN_0");
-            ConnectPortRef(fluidCoupler, "HEAT_OUT", cooler, "HEAT_IN_1");
-            ConnectPortRef(cooler, "HEAT_OUT", cooler, "HEAT_IN_2");
-            ConnectPortRef(autoCooler, "HEAT_OUT", cooler, "HEAT_IN_3");
+            ConnectPortRef(engine, "HEAT_OUT", coolant, "HEAT_IN_0");
+            ConnectPortRef(fluidCoupler, "HEAT_OUT", coolant, "HEAT_IN_1");
+            ConnectPortRef(cooler, "HEAT_OUT", coolant, "HEAT_IN_2");
+            ConnectPortRef(autoCooler, "HEAT_OUT", coolant, "HEAT_IN_3");
 
             // Apply defaults.
             ApplyMethodToAll<IDH4Defaults>(s => s.ApplyDH4Defaults());

--- a/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselHydraulicSimCreator.cs
@@ -59,7 +59,7 @@ namespace CCL.Creator.Wizards.SimSetup
             environmentDamage.damagerPortId = FullPortId(engine, "FUEL_ENV_DAMAGE_METER");
             environmentDamage.environmentDamageResource = BaseResourceType.EnvironmentDamageFuel;
             var engineExplosion = CreateSibling<ExplosionActivationOnSignalProxy>(engine);
-            engineExplosion.explosion = ExplosionPrefab.ExplosionMechanical;
+            engineExplosion.explosion = ExplosionPrefab.Mechanical;
             engineExplosion.bodyDamagePercentage = 0.1f;
             engineExplosion.explosionSignalPortId = FullPortId(engine, "IS_BROKEN");
 
@@ -74,7 +74,7 @@ namespace CCL.Creator.Wizards.SimSetup
 
             var fluidCoupler = CreateSimComponent<HydraulicTransmissionDefinitionProxy>("fluidCoupler");
             var couplerExplosion = CreateSibling<ExplosionActivationOnSignalProxy>(fluidCoupler);
-            couplerExplosion.explosion = ExplosionPrefab.ExplosionHydraulic;
+            couplerExplosion.explosion = ExplosionPrefab.Hydraulic;
             couplerExplosion.bodyDamagePercentage = 0.1f;
             couplerExplosion.windowsBreakingDelay = 0.4f;
             couplerExplosion.explosionSignalPortId = FullPortId(fluidCoupler, "IS_BROKEN");

--- a/CCL.Creator/Wizards/SimSetup/SteamerSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/SteamerSimCreator.cs
@@ -93,7 +93,7 @@ namespace CCL.Creator.Wizards.SimSetup
             explosion.wheelsDamagePercentage = 1.0f;
             explosion.mechanicalPTDamagePercentage = 1.0f;
             explosion.electricalPTDamagePercentage = 1.0f;
-            explosion.explosion = ExplosionPrefab.ExplosionBoiler;
+            explosion.explosion = ExplosionPrefab.Boiler;
             explosion.explosionSignalPortId = FullPortId(boiler, "IS_BROKEN");
             explosion.explodeTrainCar = true;
 

--- a/CCL.Importer/Processing/GrabberProcessor.cs
+++ b/CCL.Importer/Processing/GrabberProcessor.cs
@@ -49,6 +49,7 @@ namespace CCL.Importer.Processing
 
                 // Cache all resources of a type for easy access.
                 _cachedResources = Resources.FindObjectsOfTypeAll<T>()
+                    .Where(x  => x != null)
                     .GroupBy(x => x.name, StringComparer.Ordinal)
                     .ToDictionary(k => k.Key, v => v.First());
 

--- a/CCL.Importer/Processing/SimulationProcessor.cs
+++ b/CCL.Importer/Processing/SimulationProcessor.cs
@@ -92,25 +92,25 @@ namespace CCL.Importer.Processing
 
         private static void AddAdditionalControllers(GameObject prefab)
         {
-            if (prefab.GetComponentsInChildren<InteractablePortFeeder>().Length > 0)
-            {
-                var controller = prefab.AddComponent<InteractablePortFeedersController>();
-                controller.entries = prefab.GetComponentsInChildren<InteractablePortFeeder>();
-            }
-
-            if (prefab.GetComponentsInChildren<IndicatorPortReader>().Length > 0)
-            {
-                var controller = prefab.AddComponent<IndicatorPortReadersController>();
-                controller.entries = prefab.GetComponentsInChildren<IndicatorPortReader>();
-            }
-
-            if (prefab.GetComponentsInChildren<InteractableFuseFeeder>().Length > 0)
-            {
-                var controller = prefab.AddComponent<InteractableFuseFeedersController>();
-                controller.entries = prefab.GetComponentsInChildren<InteractableFuseFeeder>();
-            }
+            AddController<InteractablePortFeedersController, InteractablePortFeeder>(prefab);
+            AddController<IndicatorPortReadersController, IndicatorPortReader>(prefab);
+            AddController<InteractableFuseFeedersController, InteractableFuseFeeder>(prefab);
+            AddController<AnimatorPortReadersController, AnimatorPortReader>(prefab);
 
             // Add more wrapper controllers here - or possibly use MEF to initialize wrapper controllers?
+        }
+
+        private static void AddController<TController, TComp>(GameObject prefab)
+            where TController : ARefreshableChildrenController<TComp>
+            where TComp : MonoBehaviour
+        {
+            var entries = prefab.GetComponentsInChildren<TComp>();
+
+            if (entries.Length > 0)
+            {
+                var controller = prefab.AddComponent<TController>();
+                controller.entries = entries;
+            }
         }
 
         private static SimConnectionDefinition AttachSimConnectionsToPrefab(GameObject prefab)

--- a/CCL.Importer/Proxies/Controllers/MiscControllerReplacer.cs
+++ b/CCL.Importer/Proxies/Controllers/MiscControllerReplacer.cs
@@ -68,11 +68,11 @@ namespace CCL.Importer.Proxies.Controllers
         {
             explosion.explosionPrefab = proxy.explosion switch
             {
-                ExplosionPrefab.ExplosionBoiler => BoilerExplosion,
-                ExplosionPrefab.ExplosionElectric => ElectricExplosion,
-                ExplosionPrefab.ExplosionHydraulic => HydraulicExplosion,
-                ExplosionPrefab.ExplosionMechanical => MechanicalExplosion,
-                ExplosionPrefab.ExplosionTMOverspeed => TMOverspeedExplosion,
+                ExplosionPrefab.Boiler => BoilerExplosion,
+                ExplosionPrefab.Electric => ElectricExplosion,
+                ExplosionPrefab.Hydraulic => HydraulicExplosion,
+                ExplosionPrefab.Mechanical => MechanicalExplosion,
+                ExplosionPrefab.TMOverspeed => TMOverspeedExplosion,
                 _ => null!
             };
         }

--- a/CCL.Importer/Proxies/MiscReplacer.cs
+++ b/CCL.Importer/Proxies/MiscReplacer.cs
@@ -29,6 +29,7 @@ namespace CCL.Importer.Proxies
             CreateMap<ExplosionModelHandlerProxy, ExplosionModelHandler>().AutoCacheAndMap();
             CreateMap<ExplosionModelHandlerProxy.MaterialSwapData, ExplosionModelHandler.MaterialSwapData>();
             CreateMap<ExplosionModelHandlerProxy.GameObjectSwapData, ExplosionModelHandler.GameObjectSwapData>();
+            CreateMap<ResourceExplosionBaseProxy, ResourceExplosionBase>().AutoCacheAndMap();
 
             CreateMap<PlayerDistanceGameObjectsDisablerProxy, PlayerDistanceGameObjectsDisabler>()
                 .AutoCacheAndMap()

--- a/CCL.Importer/Proxies/PortComponentReplacer.cs
+++ b/CCL.Importer/Proxies/PortComponentReplacer.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using CCL.Types.Proxies.Ports;
 using DV.Simulation.Controllers;
+using DV.Simulation.Ports;
 using LocoSim.Definitions;
 using System.Linq;
 
@@ -26,6 +27,8 @@ namespace CCL.Importer.Proxies
 
             CreateMap<BroadcastPortValueConsumerProxy, BroadcastPortValueConsumer>().AutoCacheAndMap();
             CreateMap<BroadcastPortValueProviderProxy, BroadcastPortValueProvider>().AutoCacheAndMap();
+
+            CreateMap<AnimatorPortReaderProxy, AnimatorPortReader>().AutoCacheAndMap();
         }
     }
 }

--- a/CCL.Importer/Proxies/Weather/WeatherReplacer.cs
+++ b/CCL.Importer/Proxies/Weather/WeatherReplacer.cs
@@ -11,7 +11,8 @@ namespace CCL.Importer.Proxies.Weather
         public WeatherReplacer()
         {
             CreateMap<WindowProxy, Window>().AutoCacheAndMap()
-                .ForMember(d => d.duplicates, o => o.MapFrom(s => Mapper.GetFromCache(s.duplicates)));
+                .ForMember(d => d.duplicates, o => o.MapFrom(s => Mapper.GetFromCache(s.duplicates)))
+                .ForMember(d => d.wipers, o => o.MapFrom(s => Mapper.GetFromCache(s.wipers)));
             CreateMap<CabinDryVolumeProxy, CabinDryVolume>().AutoCacheAndMap()
                 .ForMember(d => d.subVolumes, o => o.MapFrom(s => Mapper.GetFromCache(s.subVolumes)));
 
@@ -22,6 +23,16 @@ namespace CCL.Importer.Proxies.Weather
             CreateMap<DecalLayerChannelProxy, DecalLayerChannel>();
 
             CreateMap<OpenableControlProxy, OpenableControl>().AutoCacheAndMap();
+
+            CreateMap<WipersSimControlInputProxy, WipersSimControlInput>().AutoCacheAndMap()
+                .ForMember(d => d.wiperController, o => o.MapFrom(s => Mapper.GetFromCache(s.wiperController)));
+            CreateMap<WiperControllerProxy, WiperController>().AutoCacheAndMap()
+                .ForMember(d => d.wiperDrivers, o => o.MapFrom(s => Mapper.GetFromCache(s.wiperDrivers)));
+            CreateMap<WiperDriverProxy, WiperDriver>().AutoCacheAndMap()
+                .ForMember(d => d.wiper, o => o.MapFrom(s => Mapper.GetFromCache(s.wiper)));
+            CreateMap<WiperProxy, Wiper>().AutoCacheAndMap()
+                .ForMember(d => d.windows, o => o.MapFrom(s => Mapper.GetFromCache(s.windows)));
+            CreateMap<RotaryWiperDriverProxy, RotaryWiperDriver>().AutoCacheAndMap();
         }
     }
 }

--- a/CCL.Importer/Proxies/Weather/WeatherReplacer.cs
+++ b/CCL.Importer/Proxies/Weather/WeatherReplacer.cs
@@ -28,10 +28,11 @@ namespace CCL.Importer.Proxies.Weather
                 .ForMember(d => d.wiperController, o => o.MapFrom(s => Mapper.GetFromCache(s.wiperController)));
             CreateMap<WiperControllerProxy, WiperController>().AutoCacheAndMap()
                 .ForMember(d => d.wiperDrivers, o => o.MapFrom(s => Mapper.GetFromCache(s.wiperDrivers)));
-            CreateMap<WiperDriverProxy, WiperDriver>().AutoCacheAndMap()
-                .ForMember(d => d.wiper, o => o.MapFrom(s => Mapper.GetFromCache(s.wiper)));
             CreateMap<WiperProxy, Wiper>().AutoCacheAndMap()
                 .ForMember(d => d.windows, o => o.MapFrom(s => Mapper.GetFromCache(s.windows)));
+            CreateMap<WiperDriverProxy, WiperDriver>()
+                .ForMember(d => d.wiper, o => o.MapFrom(s => Mapper.GetFromCache(s.wiper)))
+                .IncludeAllDerived();
             CreateMap<RotaryWiperDriverProxy, RotaryWiperDriver>().AutoCacheAndMap();
         }
     }

--- a/CCL.Types/Components/CopyVanillaLight.cs
+++ b/CCL.Types/Components/CopyVanillaLight.cs
@@ -209,9 +209,9 @@ namespace CCL.Types.Components
 
         private static void RemoveQuality(Light light)
         {
-            if (!light.TryGetComponent(out LightShadowQualityProxy quality))
+            if (light.TryGetComponent(out LightShadowQualityProxy quality))
             {
-                Destroy(quality);
+                DestroyImmediate(quality);
             }
         }
     }

--- a/CCL.Types/Proxies/Controllers/ExplosionActivationOnSignalProxy.cs
+++ b/CCL.Types/Proxies/Controllers/ExplosionActivationOnSignalProxy.cs
@@ -26,10 +26,10 @@ namespace CCL.Types.Proxies.Controllers
 
     public enum ExplosionPrefab
     {
-        ExplosionBoiler,
-        ExplosionElectric,
-        ExplosionHydraulic,
-        ExplosionMechanical,
-        ExplosionTMOverspeed,
+        Boiler,
+        Electric,
+        Hydraulic,
+        Mechanical,
+        TMOverspeed,
     }
 }

--- a/CCL.Types/Proxies/Ports/AnimatorPortReaderProxy.cs
+++ b/CCL.Types/Proxies/Ports/AnimatorPortReaderProxy.cs
@@ -1,0 +1,23 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Ports
+{
+    public class AnimatorPortReaderProxy : MonoBehaviour
+    {
+        public enum UpdateType
+        {
+            SET_NORMALIZED_TIME,
+            SET_PARAMETER
+        }
+
+        public UpdateType updateType;
+        [PortId(null, null, false)]
+        public string portId;
+        //[ShowIf("updateType", UpdateType.SET_PARAMETER)]
+        public string parameterName;
+
+        [Header("Value modifiers")]
+        public float valueMultiplier = 1f;
+        public float valueOffset;
+    }
+}

--- a/CCL.Types/Proxies/ResourceExplosionBaseProxy.cs
+++ b/CCL.Types/Proxies/ResourceExplosionBaseProxy.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies
+{
+    public class ResourceExplosionBaseProxy : MonoBehaviour
+    {
+        [SerializeField]
+        private BaseCargoType explosionLiquid = BaseCargoType.Diesel;
+        [SerializeField]
+        private GameObject explosionPrefab;
+        [SerializeField]
+        private Transform explosionAnchor;
+    }
+}

--- a/CCL.Types/Proxies/Weather/RotaryWiperDriverProxy.cs
+++ b/CCL.Types/Proxies/Weather/RotaryWiperDriverProxy.cs
@@ -1,0 +1,12 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Weather
+{
+    public class RotaryWiperDriverProxy : WiperDriverProxy
+    {
+        public Transform[] rotationaryTransforms;
+        public Transform stationaryTransform;
+        public float maxAngle;
+        public AnimationCurve speedCurve;
+    }
+}

--- a/CCL.Types/Proxies/Weather/WindowProxy.cs
+++ b/CCL.Types/Proxies/Weather/WindowProxy.cs
@@ -3,12 +3,11 @@ using UnityEngine;
 
 namespace CCL.Types.Proxies.Weather
 {
-    [DisallowMultipleComponent]
     public class WindowProxy : MonoBehaviour
     {
         public bool simulate = true;
         public MeshRenderer[] visuals = new MeshRenderer[0];
-        public WiperProxy[] wipers;
+        public WiperProxy[] wipers = new WiperProxy[0];
         public WindowProxy[] duplicates = new WindowProxy[0];
         public Transform[] windowEdges = new Transform[0];
         public Vector2 sizeInMeters;

--- a/CCL.Types/Proxies/Weather/WindowProxy.cs
+++ b/CCL.Types/Proxies/Weather/WindowProxy.cs
@@ -8,8 +8,7 @@ namespace CCL.Types.Proxies.Weather
     {
         public bool simulate = true;
         public MeshRenderer[] visuals = new MeshRenderer[0];
-        // To replace with WiperProxy.
-        //public Wiper[] wipers;
+        public WiperProxy[] wipers;
         public WindowProxy[] duplicates = new WindowProxy[0];
         public Transform[] windowEdges = new Transform[0];
         public Vector2 sizeInMeters;

--- a/CCL.Types/Proxies/Weather/WiperControllerProxy.cs
+++ b/CCL.Types/Proxies/Weather/WiperControllerProxy.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Weather
+{
+    public class WiperControllerProxy : MonoBehaviour
+    {
+        public float[] speeds = new float[]
+        {
+            0f,
+            1f,
+            1f,
+            2f
+        };
+
+        public float[] timeBetweenWipes = new float[0];
+        public WiperDriverProxy[] wiperDrivers = new WiperDriverProxy[0];
+        public int speedIndex = 0;
+    }
+}

--- a/CCL.Types/Proxies/Weather/WiperDriverProxy.cs
+++ b/CCL.Types/Proxies/Weather/WiperDriverProxy.cs
@@ -1,0 +1,12 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Weather
+{
+    public class WiperDriverProxy : MonoBehaviour
+    {
+        public WiperDriverProxy master;
+        public WiperProxy wiper;
+        public float speed;
+        public float timeBetweenWipes;
+    }
+}

--- a/CCL.Types/Proxies/Weather/WiperProxy.cs
+++ b/CCL.Types/Proxies/Weather/WiperProxy.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types.Proxies.Weather
+{
+    public class WiperProxy : MonoBehaviour
+    {
+        public List<WindowProxy> windows = new List<WindowProxy>();
+        public Transform start;
+        public Transform end;
+    }
+}

--- a/CCL.Types/Proxies/Weather/WipersSimControlInputProxy.cs
+++ b/CCL.Types/Proxies/Weather/WipersSimControlInputProxy.cs
@@ -1,0 +1,9 @@
+﻿using CCL.Types.Proxies.Controllers;
+
+namespace CCL.Types.Proxies.Weather
+{
+    public class WipersSimControlInputProxy : PoweredControlHandlerBase
+    {
+        public WiperControllerProxy wiperController;
+    }
+}


### PR DESCRIPTION
Added ResourceExplosionBaseProxy.
Added AnimationPortReaderProxy.
Added wipers.
* Updated windows to support wipers.

Fixed grabbers causing issues when mods that add resources with the same names load before CCL.
Fixed DH sim wizard (heat ports from cooler -> coolant).
Renamed ExplosionPrefab enum to reduce redundancy.
Some code cleanup to reduce duplication.