### PR TITLE
B99 Battery-Electric

### DIFF
--- a/CCL.Creator/Wizards/SimSetup/BatteryElectricSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/BatteryElectricSimCreator.cs
@@ -97,6 +97,7 @@ namespace CCL.Creator.Wizards.SimSetup
             };
 
             horn.powerFuseId = FullFuseId(fusebox, 0);
+            batteryController.powerFuseId = FullFuseId(fusebox, 0);
             sander.powerFuseId = FullFuseId(fusebox, 0);
             horn.powerFuseId = FullFuseId(fusebox, 0);
             tm.powerFuseId = FullFuseId(fusebox, 1);
@@ -140,7 +141,7 @@ namespace CCL.Creator.Wizards.SimSetup
             ConnectEmptyPortRef(tm, "CONFIGURATION_OVERRIDE");
 
             ConnectPortRef(tmRpm, "TM_RPM", tm, "MOTOR_RPM");
-            ConnectPortRef(voltRegulator, "TM_VOLTAGE", tm, "APPLIED_VOLTAGE");
+            ConnectPortRef(voltRegulator, "OUTPUT_VOLTAGE", tm, "APPLIED_VOLTAGE");
 
             ConnectPortRef(waterDetector, "STATE_EXT_IN", tm, "ENVIRONMENT_WATER_STATE");
 

--- a/CCL.Creator/Wizards/SimSetup/BatteryElectricSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/BatteryElectricSimCreator.cs
@@ -49,6 +49,10 @@ namespace CCL.Creator.Wizards.SimSetup
             pwrConsumCalc.addReadOut = new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.POWER, "POWER_CONSUMPTION_TOTAL");
             pwrConsumCalc.transform.parent = batteryController.transform;
 
+            var waterDetector = CreateSimComponent<WaterDetectorDefinitionProxy>("waterDetector");
+            var waterPortFeeder = CreateSibling<WaterDetectorPortFeederProxy>(waterDetector);
+            waterPortFeeder.statePortId = FullPortId(waterDetector, "STATE_EXT_IN");
+
             var sand = CreateResourceContainer(ResourceContainerType.Sand);
             var sander = CreateSanderControl();
 
@@ -57,10 +61,7 @@ namespace CCL.Creator.Wizards.SimSetup
             tmRpm.bReader = new PortReferenceDefinition(DVPortValueType.GENERIC, "GEAR_RATIO");
             tmRpm.mulReadOut = new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.RPM, "TM_RPM");
 
-            var tmController = CreateSimComponent<ConfigurableMultiplierDefinitionProxy>("tmController");
-            tmController.aReader = new PortReferenceDefinition(DVPortValueType.VOLTS, "BATTERY_VOLTAGE");
-            tmController.bReader = new PortReferenceDefinition(DVPortValueType.CONTROL, "THROTTLE");
-            tmController.mulReadOut = new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.VOLTS, "TM_VOLTAGE");
+            var voltRegulator = CreateSimComponent<VoltageRegulatorDefinitionProxy>("voltageRegulator");
 
             var tm = CreateSimComponent<TractionMotorSetDefinitionProxy>("tm");
             var deadTMs = CreateSibling<DeadTractionMotorsControllerProxy>(tm);
@@ -95,11 +96,12 @@ namespace CCL.Creator.Wizards.SimSetup
                 new FuseDefinition("TM_POWER", false),
             };
 
-            sander.powerFuseId = FullPortId(fusebox, "ELECTRICS_MAIN");
-            batteryController.powerFuseId = FullPortId(fusebox, "ELECTRICS_MAIN");
-            tm.powerFuseId = FullPortId(fusebox, "TM_POWER");
-            deadTMs.tmFuseId = FullPortId(fusebox, "TM_POWER");
-            compressor.powerFuseId = FullPortId(fusebox, "ELECTRICS_MAIN");
+            horn.powerFuseId = FullFuseId(fusebox, 0);
+            sander.powerFuseId = FullFuseId(fusebox, 0);
+            horn.powerFuseId = FullFuseId(fusebox, 0);
+            tm.powerFuseId = FullFuseId(fusebox, 1);
+            deadTMs.tmFuseId = FullFuseId(fusebox, 1);
+            compressor.powerFuseId = FullFuseId(fusebox, 0);
 
             // Damage.
             _damageController.electricalPTDamagerPortIds = new[] { FullPortId(tm, "GENERATED_DAMAGE") };
@@ -128,20 +130,26 @@ namespace CCL.Creator.Wizards.SimSetup
             ConnectPortRef(traction, "WHEEL_RPM_EXT_IN", tmRpm, "WHEEL_RPM");
             ConnectPortRef(transmission, "GEAR_RATIO", tmRpm, "GEAR_RATIO");
 
-            ConnectPortRef(batteryController, "VOLTAGE", tmController, "BATTERY_VOLTAGE");
-            ConnectPortRef(thrtCurv, "OUT", tmController, "THROTTLE");
+            ConnectPortRef(thrtCurv, "OUT", voltRegulator, "THROTTLE");
+            ConnectPortRef(batteryController, "VOLTAGE", voltRegulator, "SUPPLY_VOLTAGE");
+            ConnectPortRef(tm, "SINGLE_MOTOR_EFFECTIVE_RESISTANCE", voltRegulator, "SINGLE_MOTOR_EFFECTIVE_RESISTANCE");
 
             ConnectPortRef(throttle, "EXT_IN", tm, "THROTTLE");
             ConnectPortRef(reverser, "REVERSER", tm, "REVERSER");
+            ConnectEmptyPortRef(tm, "DYNAMIC_BRAKE");
+            ConnectEmptyPortRef(tm, "CONFIGURATION_OVERRIDE");
 
             ConnectPortRef(tmRpm, "TM_RPM", tm, "MOTOR_RPM");
-            ConnectPortRef(tmController, "TM_VOLTAGE", tm, "APPLIED_VOLTAGE");
+            ConnectPortRef(voltRegulator, "TM_VOLTAGE", tm, "APPLIED_VOLTAGE");
+
+            ConnectPortRef(waterDetector, "STATE_EXT_IN", tm, "ENVIRONMENT_WATER_STATE");
 
             ConnectPortRef(heat, "TEMPERATURE", tm, "TM_TEMPERATURE");
             ConnectPortRef(heat, "TEMPERATURE", cooler, "TEMPERATURE");
+            ConnectEmptyPortRef(cooler, "TARGET_TEMPERATURE");
 
-            ConnectPortRef(tm, "HEAT_OUT", heat, "HEAT_IN_0");
-            ConnectPortRef(cooler, "HEAT_OUT", heat, "HEAT_IN_1");
+            ConnectHeatRef(tm, "HEAT_OUT", heat, 0);
+            ConnectHeatRef(cooler, "HEAT_OUT", heat, 1);
 
             // Apply defaults.
             ApplyMethodToAll<IBE2Defaults>(s => s.ApplyBE2Defaults());

--- a/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
+++ b/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
@@ -427,7 +427,7 @@ namespace CCL.Creator.Wizards.SimSetup
         {
             _connectionDef.portReferenceConnections.Add(new PortReferenceConnectionProxy()
             {
-                portId = Utilities.EmptyPort,
+                portId = string.Empty,
                 portReferenceId = FullPortId(refComp, refId)
             });
         }

--- a/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
+++ b/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
@@ -1,4 +1,5 @@
 ﻿using CCL.Creator.Utility;
+using CCL.Types;
 using CCL.Types.Proxies.Controllers;
 using CCL.Types.Proxies.Controls;
 using CCL.Types.Proxies.Ports;
@@ -253,6 +254,13 @@ namespace CCL.Creator.Wizards.SimSetup
             var overrider = CreateSibling<OverridableControlProxy>(control);
             overrider.ControlType = type;
             overrider.portId = $"{idOverride}.EXT_IN";
+
+            control.saveState = type switch
+            {
+                OverridableControlType.TrainBrakeCutout => true,
+                _ => false,
+            };
+
             return control;
         }
 
@@ -366,6 +374,7 @@ namespace CCL.Creator.Wizards.SimSetup
 
         protected string FullPortId(SimComponentDefinitionProxy component, string portId) => $"{component.ID}.{portId}";
         protected string FullFuseId(IndependentFusesDefinitionProxy fusebox, int index) => $"{fusebox.ID}.{fusebox.fuses[index].id}";
+        protected string HeatPortId(HeatReservoirDefinitionProxy heat, int index) => $"{heat.ID}.HEAT_IN_{index}";
 
         protected void ConnectPorts(string fullSourceId, string fullDestId)
         {
@@ -399,6 +408,26 @@ namespace CCL.Creator.Wizards.SimSetup
             _connectionDef.portReferenceConnections.Add(new PortReferenceConnectionProxy()
             {
                 portId = FullPortId(portComp, portId),
+                portReferenceId = FullPortId(refComp, refId)
+            });
+        }
+
+        protected void ConnectHeatRef(SimComponentDefinitionProxy portComp, string portId, HeatReservoirDefinitionProxy refComp, int index)
+        {
+            _connectionDef.portReferenceConnections.Add(new PortReferenceConnectionProxy()
+            {
+                portId = FullPortId(portComp, portId),
+                portReferenceId = HeatPortId(refComp, index)
+            });
+        }
+
+        // This may be used by as placeholder for unconnected ports, instead of needing to add a port later from scratch.
+        // A few locomotives have empty ports defined like so.
+        protected void ConnectEmptyPortRef(SimComponentDefinitionProxy refComp, string refId)
+        {
+            _connectionDef.portReferenceConnections.Add(new PortReferenceConnectionProxy()
+            {
+                portId = Utilities.EmptyPort,
                 portReferenceId = FullPortId(refComp, refId)
             });
         }

--- a/CCL.Creator/Wizards/SimSetup/SteamerSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/SteamerSimCreator.cs
@@ -267,7 +267,7 @@ namespace CCL.Creator.Wizards.SimSetup
                     ConnectPortRef(steamEngine, "EXHAUST_TEMPERATURE", boiler, "FEEDWATER_TEMPERATURE");
                     break;
                 default:
-                    ConnectPortRef("-EMPTY-", FullPortId(boiler, "FEEDWATER_TEMPERATURE"));
+                    ConnectEmptyPortRef(boiler, "FEEDWATER_TEMPERATURE");
                     break;
             }
             ConnectPortRef(steamCalc, "OUT", boiler, "STEAM_CONSUMPTION");

--- a/CCL.Importer/Mapper.cs
+++ b/CCL.Importer/Mapper.cs
@@ -133,7 +133,8 @@ namespace CCL.Importer
                 .ForMember(c => c.liveries, o => o.ConvertUsing(new LiveriesConverter()))
                 .ForMember(c => c.rollingResistanceMultiplier, o => o.MapFrom(ccl => ccl.rollingResistanceCoefficient / CustomCarType.ROLLING_RESISTANCE_COEFFICIENT))
                 .ForMember(c => c.wheelSlideFrictionMultiplier, o => o.MapFrom(ccl => ccl.wheelSlidingFrictionCoefficient / CustomCarType.WHEELSLIDE_FRICTION_COEFFICIENT))
-                .ForMember(c => c.wheelslipFrictionMultiplier, o => o.MapFrom(ccl => ccl.wheelslipFrictionCoefficient / CustomCarType.WHEELSLIP_FRICTION_COEFFICIENT));
+                .ForMember(c => c.wheelslipFrictionMultiplier, o => o.MapFrom(ccl => ccl.wheelslipFrictionCoefficient / CustomCarType.WHEELSLIP_FRICTION_COEFFICIENT))
+                .ForMember(c => c.audioPoolSize, o => o.MapFrom(ccl => Utilities.GetAudioPoolSize(ccl.KindSelection)));
 
             cfg.CreateMap<CustomCarType.BrakesSetup, TrainCarType_v2.BrakesSetup>()
                 .ForMember(b => b.trainBrake, o => o.MapFrom(s => s.brakeValveType));

--- a/CCL.Importer/Proxies/Controllers/MiscControllerReplacer.cs
+++ b/CCL.Importer/Proxies/Controllers/MiscControllerReplacer.cs
@@ -23,22 +23,22 @@ namespace CCL.Importer.Proxies.Controllers
         private static GameObject? s_fireExplosion;
 
         private static DeadTractionMotorsController DE6DeadTM => Extensions.GetCached(ref s_de6deadTM,
-            () => TrainCarType.LocoDiesel.ToV2().prefab.GetComponentInChildren<DeadTractionMotorsController>());
+            () => QuickAccess.Locomotives.DE6.prefab.GetComponentInChildren<DeadTractionMotorsController>());
         private static GameObject BoilerExplosion => Extensions.GetCached(ref s_boilerExplosion,
-            () => TrainCarType.LocoSteamHeavy.ToV2().prefab.GetComponentInChildren<BoilerDefinition>()
+            () => QuickAccess.Locomotives.S282A.prefab.GetComponentInChildren<BoilerDefinition>()
                 .GetComponent<ExplosionActivationOnSignal>().explosionPrefab);
         private static GameObject ElectricExplosion => Extensions.GetCached(ref s_electricExplosion,
             () => DE6DeadTM.tmBlowPrefab);
         private static GameObject HydraulicExplosion => Extensions.GetCached(ref s_hydraulicExplosion,
-            () => TrainCarType.LocoDH4.ToV2().prefab.GetComponentInChildren<HydraulicTransmissionDefinition>()
+            () => QuickAccess.Locomotives.DH4.prefab.GetComponentInChildren<HydraulicTransmissionDefinition>()
                 .GetComponent<ExplosionActivationOnSignal>().explosionPrefab);
         private static GameObject MechanicalExplosion => Extensions.GetCached(ref s_mechanicalExplosion,
-            () => TrainCarType.LocoDM3.ToV2().prefab.GetComponentInChildren<DieselEngineDirectDefinition>()
+            () => QuickAccess.Locomotives.DM3.prefab.GetComponentInChildren<DieselEngineDirectDefinition>()
                 .GetComponent<ExplosionActivationOnSignal>().explosionPrefab);
         private static GameObject TMOverspeedExplosion => Extensions.GetCached(ref s_tmOverspeedExplosion,
             () => DE6DeadTM.GetComponent<ExplosionActivationOnSignal>().explosionPrefab);
         private static GameObject FireExplosion => Extensions.GetCached(ref s_fireExplosion,
-            () => TrainCarType.LocoSteamHeavy.ToV2().prefab.GetComponentInChildren<BlowbackParticlePortReader>().blowbackParticlesPrefab);
+            () => QuickAccess.Locomotives.S282A.prefab.GetComponentInChildren<BlowbackParticlePortReader>().blowbackParticlesPrefab);
 
         public MiscControllerReplacer()
         {

--- a/CCL.Importer/Proxies/Indicators/IndicatorProxyMapper.cs
+++ b/CCL.Importer/Proxies/Indicators/IndicatorProxyMapper.cs
@@ -4,6 +4,7 @@ using DV.Indicators;
 using DV.Localization;
 using DV.Simulation.Brake;
 using DV.Simulation.Fuses;
+using DV.Simulation.Lamps;
 using DV.Simulation.Ports;
 
 namespace CCL.Importer.Proxies.Indicators
@@ -30,6 +31,7 @@ namespace CCL.Importer.Proxies.Indicators
             CreateMap<LampBrakeIssueReaderProxy, LampBrakeLeaksAndHandbrakeStateReader>().AutoCacheAndMap();
             CreateMap<LampControlProxy, LampControl>().AutoCacheAndMap()
                 .ForMember(d => d.lampInd, o => o.MapFrom(s => Mapper.GetFromCache(s.lampInd)));
+            CreateMap<LampWheelSlipSlideReaderProxy, LampWheelSlipSlideReader>().AutoCacheAndMap();
 
             CreateMap<LabelLocalizer, Localize>();
         }

--- a/CCL.Importer/Proxies/Simulation/ElectricSimulationReplacer.cs
+++ b/CCL.Importer/Proxies/Simulation/ElectricSimulationReplacer.cs
@@ -17,6 +17,7 @@ namespace CCL.Importer.Proxies.Simulation
             CreateMap<TractionGeneratorDefinitionProxy, TractionGeneratorDefinition>().AutoCacheAndMap();
 
             CreateMap<BatteryDefinitionProxy, BatteryDefinition>().AutoCacheAndMap();
+            CreateMap<VoltageRegulatorDefinitionProxy, VoltageRegulatorDefinition>().AutoCacheAndMap();
             CreateMap<ElectricCompressorDefinitionProxy, ElectricCompressorDefinition>().AutoCacheAndMap();
             CreateMap<PowerFunctionDefinitionProxy, PowerFunctionDefinition>().AutoCacheAndMap();
 

--- a/CCL.Types/CustomCarType.cs
+++ b/CCL.Types/CustomCarType.cs
@@ -17,6 +17,16 @@ namespace CCL.Types
         Slug
     }
 
+    public enum UnusedCarDeletePreventionMode
+    {
+        None = 0,
+        TimeBasedCarVisit = 10,
+        TimeBasedCarVisitPropagatedToFrontCar = 11,
+        TimeBasedCarVisitPropagatedToRearCar = 12,
+        TimeBasedCarVisitPropagatedToFrontAndRearCar = 13,
+        OnlyManualDeletePossible = 20
+    }
+
     [CreateAssetMenu(menuName = "CCL/Custom Car Type")]
     public class CustomCarType : ScriptableObject, IAssetLoadCallback
     {
@@ -259,15 +269,5 @@ namespace CCL.Types
     public interface IAssetLoadCallback
     {
         void AfterAssetLoad(AssetBundle bundle);
-    }
-
-    public enum UnusedCarDeletePreventionMode
-    {
-        None = 0,
-        TimeBasedCarVisit = 10,
-        TimeBasedCarVisitPropagatedToFrontCar = 11,
-        TimeBasedCarVisitPropagatedToRearCar = 12,
-        TimeBasedCarVisitPropagatedToFrontAndRearCar = 13,
-        OnlyManualDeletePossible = 20
     }
 }

--- a/CCL.Types/Proxies/Indicators/IndicatorGaugeProxy.cs
+++ b/CCL.Types/Proxies/Indicators/IndicatorGaugeProxy.cs
@@ -51,6 +51,7 @@ namespace CCL.Types.Proxies.Indicators
 
     public class IndicatorGaugeLaggingProxy : IndicatorGaugeProxy
     {
+        public float updateThreshold = 0.001f;
         public float smoothTime = 0.5f;
 
         [NonSerialized]

--- a/CCL.Types/Proxies/Indicators/LampWheelSlipSlideReaderProxy.cs
+++ b/CCL.Types/Proxies/Indicators/LampWheelSlipSlideReaderProxy.cs
@@ -1,0 +1,24 @@
+﻿using CCL.Types.Proxies.Ports;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types.Proxies.Indicators
+{
+    public class LampWheelSlipSlideReaderProxy : MonoBehaviour, IHasFuseIdFields
+    {
+        public enum WheelslipDetectionMode
+        {
+            Individual,
+            MultipleUnit
+        }
+
+        public WheelslipDetectionMode wheelslipDetectionMode;
+        [FuseId]
+        public string fuseId;
+
+        public IEnumerable<FuseIdField> ExposedFuseIdFields => new[]
+        {
+            new FuseIdField(this, nameof(fuseId), fuseId),
+        };
+    }
+}

--- a/CCL.Types/Proxies/SimDefaultInterfaces.cs
+++ b/CCL.Types/Proxies/SimDefaultInterfaces.cs
@@ -34,4 +34,9 @@
     {
         void ApplyS282Defaults();
     }
+
+    public interface IDM1UDefaults
+    {
+        void ApplyDM1UDefaults();
+    }
 }

--- a/CCL.Types/Proxies/Simulation/Electric/TractionMotorSetDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/Electric/TractionMotorSetDefinitionProxy.cs
@@ -53,6 +53,7 @@ namespace CCL.Types.Proxies.Simulation.Electric
         {
             new PortDefinition(DVPortType.OUT, DVPortValueType.TORQUE, "TORQUE_OUT"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.OHMS, "EFFECTIVE_RESISTANCE"),
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.OHMS, "SINGLE_MOTOR_EFFECTIVE_RESISTANCE"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.AMPS, "TOTAL_AMPS"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.AMPS, "TOTAL_AMPS_NORMALIZED"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.AMPS, "AMPS_PER_TM"),
@@ -61,7 +62,7 @@ namespace CCL.Types.Proxies.Simulation.Electric
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.GENERIC, "WORKING_TRACTION_MOTORS"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.HEAT_RATE, "HEAT_OUT"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.STATE, "CONTACTOR_CHANGE"),
-            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.STATE, "CURRENT_DROP_REQUEST"),
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.AMPS, "CURRENT_LIMIT_REQUEST"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.STATE, "DYNAMIC_BRAKE_ACTIVE"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.STATE, "OVERHEAT_POWER_FUSE_OFF"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.STATE, "TMS_STATE"),
@@ -84,7 +85,8 @@ namespace CCL.Types.Proxies.Simulation.Electric
             new PortReferenceDefinition(DVPortValueType.CONTROL, "CONFIGURATION_OVERRIDE", false),
             new PortReferenceDefinition(DVPortValueType.RPM, "MOTOR_RPM", false),
             new PortReferenceDefinition(DVPortValueType.VOLTS, "APPLIED_VOLTAGE", false),
-            new PortReferenceDefinition(DVPortValueType.TEMPERATURE, "TM_TEMPERATURE", false)
+            new PortReferenceDefinition(DVPortValueType.TEMPERATURE, "TM_TEMPERATURE", false),
+            new PortReferenceDefinition(DVPortValueType.STATE, "ENVIRONMENT_WATER_STATE", false)
         };
 
         public IEnumerable<FuseIdField> ExposedFuseIdFields => new[]

--- a/CCL.Types/Proxies/Simulation/Electric/VoltageRegulatorDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/Electric/VoltageRegulatorDefinitionProxy.cs
@@ -1,0 +1,22 @@
+﻿using CCL.Types.Proxies.Ports;
+using System.Collections.Generic;
+
+namespace CCL.Types.Proxies.Simulation.Electric
+{
+    public class VoltageRegulatorDefinitionProxy : SimComponentDefinitionProxy
+    {
+        public override IEnumerable<PortDefinition> ExposedPorts => new[]
+{
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.VOLTS, "OUTPUT_VOLTAGE"),
+            new PortDefinition(DVPortType.EXTERNAL_IN, DVPortValueType.AMPS, "EXTERNAL_CURRENT_LIMIT_EXT_IN"),
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.STATE, "EXTERNAL_CURRENT_LIMIT_ACTIVE")
+        };
+
+        public override IEnumerable<PortReferenceDefinition> ExposedPortReferences => new[]
+        {
+            new PortReferenceDefinition(DVPortValueType.CONTROL, "THROTTLE", false),
+            new PortReferenceDefinition(DVPortValueType.VOLTS, "SUPPLY_VOLTAGE", false),
+            new PortReferenceDefinition(DVPortValueType.OHMS, "SINGLE_MOTOR_EFFECTIVE_RESISTANCE", false)
+        };
+    }
+}

--- a/CCL.Types/Proxies/Simulation/HeatReservoirDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/HeatReservoirDefinitionProxy.cs
@@ -6,10 +6,12 @@ using UnityEngine;
 
 namespace CCL.Types.Proxies.Simulation
 {
-    public class HeatReservoirDefinitionProxy : SimComponentDefinitionProxy, ICustomSerialized, IDE2Defaults, IDE6Defaults, IBE2Defaults
+    public class HeatReservoirDefinitionProxy : SimComponentDefinitionProxy, ICustomSerialized,
+        IDE2Defaults, IDE6Defaults, IBE2Defaults, IDM3Defaults, IDH4Defaults, IDM1UDefaults
     {
         public float heatCapacity = 1f;
         public float overheatingTemperatureThreshold = 120f;
+        public float maxTemperature = 300f;
 
         [Delayed]
         public int inputCount = 1;
@@ -49,22 +51,47 @@ namespace CCL.Types.Proxies.Simulation
         }
 
         #region Defaults
+
         public void ApplyDE2Defaults()
         {
             heatCapacity = 1000.0f;
             overheatingTemperatureThreshold = 120.0f;
+            maxTemperature = 300f;
         }
 
         public void ApplyDE6Defaults()
         {
             heatCapacity = 15000.0f;
             overheatingTemperatureThreshold = 120.0f;
+            maxTemperature = 300f;
         }
 
         public void ApplyBE2Defaults()
         {
             heatCapacity = 500.0f;
             overheatingTemperatureThreshold = 120.0f;
+            maxTemperature = 300f;
+        }
+
+        public void ApplyDM3Defaults()
+        {
+            heatCapacity = 100000.0f;
+            overheatingTemperatureThreshold = 120.0f;
+            maxTemperature = 300f;
+        }
+
+        public void ApplyDH4Defaults()
+        {
+            heatCapacity = 500000.0f;
+            overheatingTemperatureThreshold = 120.0f;
+            maxTemperature = 300f;
+        }
+
+        public void ApplyDM1UDefaults()
+        {
+            heatCapacity = 250000.0f;
+            overheatingTemperatureThreshold = 120.0f;
+            maxTemperature = 300f;
         }
 
         #endregion

--- a/CCL.Types/Proxies/Wheels/WheelRotationBaseProxy.cs
+++ b/CCL.Types/Proxies/Wheels/WheelRotationBaseProxy.cs
@@ -5,5 +5,6 @@ namespace CCL.Types.Proxies.Wheels
     public abstract class WheelRotationBaseProxy : MonoBehaviour
     {
         public float wheelRadius = 0.7f;
+        public bool affectedByWheelSlide = true;
     }
 }

--- a/CCL.Types/Utilities.cs
+++ b/CCL.Types/Utilities.cs
@@ -5,8 +5,6 @@ namespace CCL.Types
 {
     public static class Utilities
     {
-        public const string EmptyPort = "-EMPTY-";
-
         public static bool IsVanillaLicense(string id)
         {
             return IdV2.GeneralLicenses.Any(x => x == id) || IdV2.JobLicenses.Any(x => x == id);

--- a/CCL.Types/Utilities.cs
+++ b/CCL.Types/Utilities.cs
@@ -5,6 +5,8 @@ namespace CCL.Types
 {
     public static class Utilities
     {
+        public const string EmptyPort = "-EMPTY-";
+
         public static bool IsVanillaLicense(string id)
         {
             return IdV2.GeneralLicenses.Any(x => x == id) || IdV2.JobLicenses.Any(x => x == id);

--- a/CCL.Types/Utilities.cs
+++ b/CCL.Types/Utilities.cs
@@ -21,5 +21,12 @@ namespace CCL.Types
             target.localRotation = source.localRotation;
             target.localScale = source.localScale;
         }
+
+        public static int GetAudioPoolSize(DVTrainCarKind kind) => kind switch
+        {
+            DVTrainCarKind.Loco => 10,
+            DVTrainCarKind.Slug => 1,
+            _ => 0,
+        };
     }
 }


### PR DESCRIPTION
Added LampWheelSlipSlideReaderProxy.
Added VoltageRegulatorDefinitionProxy.
Added DM1U defaults interface.
* Actual defaults have not been filled in, only on the `HeatReservoirDefinitionProxy`.

Updated BE wizard.
* Includes some extra quick port functions to reduce errors and more easily show intention.
  * ConnectEmptyPortRef for port ref connections intentionally left empty.
  * ConnectHeatRef for auto-generated heat ports.

Updated WheelRotationBaseProxy.