### PR TITLE
Virtual Handbrake/Autocoupler

### DIFF
--- a/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
+++ b/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
@@ -1,4 +1,5 @@
 ﻿using CCL.Types;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -81,6 +82,27 @@ namespace CCL.Creator.Inspector
         {
             return EditorGUIUtility.singleLineHeight * 2;
         }
+
+        // Easy adding of extra options to prevent duplicate code.
+        public void OnGUIWithExtraOptions(Rect position, SerializedProperty property, GUIContent label, IEnumerable<string> extraOptions)
+        {
+            var att = (StringAndSelectorFieldAttribute)attribute;
+
+            if (att.CustomAllowed)
+            {
+                var original = att.Options.ToList();
+
+                att.Options.InsertRange(att.Options.Count - 1, extraOptions);
+
+                base.OnGUI(position, property, label);
+
+                att.Options = original;
+            }
+            else
+            {
+                base.OnGUI(position, property, label);
+            }
+        }
     }
 
     // These are needed to include the extra options from the settings.
@@ -91,22 +113,7 @@ namespace CCL.Creator.Inspector
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            var att = (StringAndSelectorFieldAttribute)attribute;
-
-            if (att.CustomAllowed)
-            {
-                var original = att.Options.ToList();
-
-                att.Options.InsertRange(att.Options.Count - 1, CCLEditorSettings.Settings.ExtraCargos);
-
-                base.OnGUI(position, property, label);
-
-                att.Options = original;
-            }
-            else
-            {
-                base.OnGUI(position, property, label);
-            }
+            OnGUIWithExtraOptions(position, property, label, CCLEditorSettings.Settings.ExtraCargos);
         }
     }
 
@@ -115,22 +122,7 @@ namespace CCL.Creator.Inspector
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            var att = (StringAndSelectorFieldAttribute)attribute;
-
-            if (att.CustomAllowed)
-            {
-                var original = att.Options.ToList();
-
-                att.Options.InsertRange(att.Options.Count - 1, CCLEditorSettings.Settings.ExtraGeneralLicenses);
-
-                base.OnGUI(position, property, label);
-
-                att.Options = original;
-            }
-            else
-            {
-                base.OnGUI(position, property, label);
-            }
+            OnGUIWithExtraOptions(position, property, label, CCLEditorSettings.Settings.ExtraGeneralLicenses);
         }
     }
 
@@ -139,22 +131,7 @@ namespace CCL.Creator.Inspector
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            var att = (StringAndSelectorFieldAttribute)attribute;
-
-            if (att.CustomAllowed)
-            {
-                var original = att.Options.ToList();
-
-                att.Options.InsertRange(att.Options.Count - 1, CCLEditorSettings.Settings.ExtraJobLicenses);
-
-                base.OnGUI(position, property, label);
-
-                att.Options = original;
-            }
-            else
-            {
-                base.OnGUI(position, property, label);
-            }
+            OnGUIWithExtraOptions(position, property, label, CCLEditorSettings.Settings.ExtraJobLicenses);
         }
     }
 
@@ -163,47 +140,17 @@ namespace CCL.Creator.Inspector
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            var att = (StringAndSelectorFieldAttribute)attribute;
-
-            if (att.CustomAllowed)
-            {
-                var original = att.Options.ToList();
-
-                att.Options.InsertRange(att.Options.Count - 1, CCLEditorSettings.Settings.ExtraGeneralLicenses);
-                att.Options.InsertRange(att.Options.Count - 1, CCLEditorSettings.Settings.ExtraJobLicenses);
-
-                base.OnGUI(position, property, label);
-
-                att.Options = original;
-            }
-            else
-            {
-                base.OnGUI(position, property, label);
-            }
+            OnGUIWithExtraOptions(position, property, label,
+                CCLEditorSettings.Settings.ExtraGeneralLicenses.Concat(CCLEditorSettings.Settings.ExtraJobLicenses));
         }
     }
 
-    [CustomPropertyDrawer(typeof(JobLicenseFieldAttribute), true)]
+    [CustomPropertyDrawer(typeof(PaintFieldAttribute), true)]
     internal class PaintFieldAttributeEditor : StringAndSelectorFieldAttributeEditor
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            var att = (StringAndSelectorFieldAttribute)attribute;
-
-            if (att.CustomAllowed)
-            {
-                var original = att.Options.ToList();
-
-                att.Options.InsertRange(att.Options.Count - 1, CCLEditorSettings.Settings.ExtraPaints);
-
-                base.OnGUI(position, property, label);
-
-                att.Options = original;
-            }
-            else
-            {
-                base.OnGUI(position, property, label);
-            }
+            OnGUIWithExtraOptions(position, property, label, CCLEditorSettings.Settings.ExtraPaints);
         }
     }
 }

--- a/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
+++ b/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
@@ -94,13 +94,13 @@ namespace CCL.Creator.Inspector
 
                 att.Options.InsertRange(att.Options.Count - 1, extraOptions);
 
-                base.OnGUI(position, property, label);
+                OnGUI(position, property, label);
 
                 att.Options = original;
             }
             else
             {
-                base.OnGUI(position, property, label);
+                OnGUI(position, property, label);
             }
         }
     }

--- a/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
+++ b/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
@@ -15,7 +15,7 @@ namespace CCL.Creator.Inspector
 
         private int _selected = 0;
 
-        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        private void OnGUIInternal(Rect position, SerializedProperty property, GUIContent label)
         {
             var att = (StringAndSelectorFieldAttribute)attribute;
 
@@ -78,6 +78,11 @@ namespace CCL.Creator.Inspector
             }
         }
 
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            OnGUIInternal(position, property, label);
+        }
+
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
             return EditorGUIUtility.singleLineHeight * 2;
@@ -94,13 +99,13 @@ namespace CCL.Creator.Inspector
 
                 att.Options.InsertRange(att.Options.Count - 1, extraOptions);
 
-                OnGUI(position, property, label);
+                OnGUIInternal(position, property, label);
 
                 att.Options = original;
             }
             else
             {
-                OnGUI(position, property, label);
+                OnGUIInternal(position, property, label);
             }
         }
     }

--- a/CCL.Importer/CCL.Importer.csproj
+++ b/CCL.Importer/CCL.Importer.csproj
@@ -40,6 +40,7 @@
 		<Reference Include="UnityEngine.UI" />
 		<Reference Include="DVLangHelper.Data" />
 		<Reference Include="DVLangHelper.Runtime" />
+		<Reference Include="DV.BrakeSystem" />
 		<Reference Include="DV.Common" />
 		<Reference Include="DV.Interaction" />
 		<Reference Include="DV.Localization" />

--- a/CCL.Importer/CCLPlugin.cs
+++ b/CCL.Importer/CCLPlugin.cs
@@ -46,6 +46,7 @@ namespace CCL.Importer
             //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.resources.OrderBy(x => x.v1).Select(x => x.id))}\"");
             //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.Liveries.OrderBy(x => x.v1).Select(x => x.id))}\"");
             //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.carTypes.Select(x => x.id))}\"");
+            //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.CarKinds.Select(x => x.id))}\"");
 
             return true;
         }

--- a/CCL.Importer/CCLPlugin.cs
+++ b/CCL.Importer/CCLPlugin.cs
@@ -39,13 +39,13 @@ namespace CCL.Importer
             var harmony = new Harmony(CCLPluginInfo.Guid);
             harmony.PatchAll(Assembly.GetExecutingAssembly());
 
-            //Log(string.Join("\",\n\"", DV.Globals.G.Types.cargos.OrderBy(x => x.v1).Select(x => x.id)));
-            //Log(string.Join("\",\n\"", DV.Globals.G.Types.generalLicenses.OrderBy(x => x.v1).Select(x => x.id)));
-            //Log(string.Join("\",\n\"", DV.Globals.G.Types.jobLicenses.OrderBy(x => x.v1).Select(x => x.id)));
-            //Log(string.Join("\",\n\"", DV.Globals.G.Types.garages.OrderBy(x => x.v1).Select(x => x.id)));
-            //Log(string.Join("\",\n\"", DV.Globals.G.Types.resources.OrderBy(x => x.v1).Select(x => x.id)));
-            //Log(string.Join("\",\n\"", DV.Globals.G.Types.Liveries.OrderBy(x => x.v1).Select(x => x.id)));
-            //Log(string.Join("\",\n\"", DV.Globals.G.Types.carTypes.Select(x => x.id)));
+            //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.cargos.OrderBy(x => x.v1).Select(x => x.id))}\"");
+            //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.generalLicenses.OrderBy(x => x.v1).Select(x => x.id))}\"");
+            //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.jobLicenses.OrderBy(x => x.v1).Select(x => x.id))}\"");
+            //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.garages.OrderBy(x => x.v1).Select(x => x.id))}\"");
+            //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.resources.OrderBy(x => x.v1).Select(x => x.id))}\"");
+            //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.Liveries.OrderBy(x => x.v1).Select(x => x.id))}\"");
+            //Log($"\"{string.Join("\",\n\"", DV.Globals.G.Types.carTypes.Select(x => x.id))}\"");
 
             return true;
         }

--- a/CCL.Importer/Components/CarAutoCouplerInternal.cs
+++ b/CCL.Importer/Components/CarAutoCouplerInternal.cs
@@ -1,0 +1,148 @@
+﻿using CCL.Types.Components;
+using DV.ThingTypes;
+using System.Collections;
+using UnityEngine;
+
+namespace CCL.Importer.Components
+{
+    internal class CarAutoCouplerInternal : MonoBehaviour
+    {
+        private const float AUTOCOUPLE_RANGE = 2.5f;
+        private const float START_CHECKING_WAIT_TIME_LONG = 4f;
+        private const float START_CHECKING_WAIT_TIME_SHORT = 1f;
+        private const float CHECK_PERIOD = 2f;
+
+        private Coupler _coupler = null!;
+        private Coroutine? _checkAutoCoupleCoro;
+
+        public CouplerDirection Direction;
+        public bool AlwaysCouple = false;
+        public string[] CarKinds = new string[0];
+        public string[] CarTypes = new string[0];
+        public string[] CarLiveries = new string[0];
+
+        private IEnumerator Start()
+        {
+            var car = GetComponent<TrainCar>();
+            _coupler = Direction == CouplerDirection.Front ? car.frontCoupler : car.rearCoupler;
+
+            if (_coupler == null)
+            {
+                Debug.LogError("CarAutoCoupler couldn't find Coupler component during init", this);
+                yield break;
+            }
+
+            yield return WaitFor.Seconds(1.5f);
+
+            StartAutoCoupleCoroIfConditionsFulfilled(true);
+            SetupListeners(true);
+        }
+
+        private void OnDisable()
+        {
+            if (UnloadWatcher.isUnloading) return;
+
+            KillAutoCoupleCoro();
+        }
+
+        private void SetupListeners(bool on)
+        {
+            if (on)
+            {
+                _coupler.Coupled += OnCoupled;
+                _coupler.Uncoupled += OnUncouple;
+                _coupler.train.OnRerailed += OnRerailed;
+                _coupler.train.OnDerailed += OnDerailed;
+            }
+            else
+            {
+                _coupler.Coupled -= OnCoupled;
+                _coupler.Uncoupled -= OnUncouple;
+                _coupler.train.OnRerailed -= OnRerailed;
+                _coupler.train.OnDerailed -= OnDerailed;
+            }
+        }
+
+        private IEnumerator CheckTenderAutoCouple(bool longStartWait)
+        {
+            yield return WaitFor.Seconds(longStartWait ? START_CHECKING_WAIT_TIME_LONG : START_CHECKING_WAIT_TIME_SHORT);
+
+            while (true)
+            {
+                yield return WaitFor.Seconds(CHECK_PERIOD);
+
+                if (_coupler.IsCoupled()) break;
+
+                Coupler firstCouplerInRange = _coupler.GetFirstCouplerInRange(2.5f);
+                if (firstCouplerInRange != null && !firstCouplerInRange.IsCoupled())
+                {
+                    TrainCar car = firstCouplerInRange.train;
+                    if (!car.derailed && MeetsConditions(car.carLivery) && !(car.frontCoupler != firstCouplerInRange))
+                    {
+                        _coupler.TryCouple(true, false, AUTOCOUPLE_RANGE);
+
+                        if (_coupler.IsCoupled())
+                        {
+                            _checkAutoCoupleCoro = null;
+                            yield break;
+                        }
+
+                        Debug.LogError("Unexpected state, failed couple attempt!", this);
+                    }
+                }
+            }
+
+            Debug.LogError("Unexpected state, coro shouldn't run if coupler is coupled!", this);
+            _checkAutoCoupleCoro = null;
+        }
+
+        private void OnRerailed() => StartAutoCoupleCoroIfConditionsFulfilled(false);
+
+        private void OnUncouple(object sender, UncoupleEventArgs e) => StartAutoCoupleCoroIfConditionsFulfilled(true);
+
+        private void OnCoupled(object sender, CoupleEventArgs e) => KillAutoCoupleCoro();
+
+        private void OnDerailed(TrainCar _) => KillAutoCoupleCoro();
+
+        private void StartAutoCoupleCoroIfConditionsFulfilled(bool longStartWait)
+        {
+            KillAutoCoupleCoro();
+
+            if (!_coupler.train.derailed && !_coupler.IsCoupled())
+            {
+                _checkAutoCoupleCoro = StartCoroutine(CheckTenderAutoCouple(longStartWait));
+            }
+        }
+
+        private void KillAutoCoupleCoro()
+        {
+            if (_checkAutoCoupleCoro != null)
+            {
+                StopCoroutine(_checkAutoCoupleCoro);
+                _checkAutoCoupleCoro = null;
+            }
+        }
+
+        private bool MeetsConditions(TrainCarLivery car)
+        {
+            if (AlwaysCouple) return true;
+
+            foreach (var item in CarKinds)
+            {
+                if (car.parentType.kind.id == item) return true;
+            }
+
+            foreach (var item in CarTypes)
+            {
+                if (car.parentType.id == item) return true;
+            }
+
+            foreach (var item in CarLiveries)
+            {
+                if (car.id == item) return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/CCL.Importer/Components/CarAutoCouplerInternal.cs
+++ b/CCL.Importer/Components/CarAutoCouplerInternal.cs
@@ -16,6 +16,7 @@ namespace CCL.Importer.Components
         private Coroutine? _checkAutoCoupleCoro;
 
         public CouplerDirection Direction;
+        public CouplerDirection OtherDirection;
         public bool AlwaysCouple = false;
         public string[] CarKinds = new string[0];
         public string[] CarTypes = new string[0];
@@ -73,11 +74,12 @@ namespace CCL.Importer.Components
 
                 if (_coupler.IsCoupled()) break;
 
-                Coupler firstCouplerInRange = _coupler.GetFirstCouplerInRange(2.5f);
+                var firstCouplerInRange = _coupler.GetFirstCouplerInRange(AUTOCOUPLE_RANGE);
                 if (firstCouplerInRange != null && !firstCouplerInRange.IsCoupled())
                 {
-                    TrainCar car = firstCouplerInRange.train;
-                    if (!car.derailed && MeetsConditions(car.carLivery) && !(car.frontCoupler != firstCouplerInRange))
+                    var car = firstCouplerInRange.train;
+                    var otherCoupler = OtherDirection == CouplerDirection.Front ? car.frontCoupler : car.rearCoupler;
+                    if (!car.derailed && MeetsConditions(car.carLivery) && otherCoupler == firstCouplerInRange)
                     {
                         _coupler.TryCouple(true, false, AUTOCOUPLE_RANGE);
 

--- a/CCL.Importer/Components/CarAutoCouplerInternal.cs
+++ b/CCL.Importer/Components/CarAutoCouplerInternal.cs
@@ -1,4 +1,4 @@
-﻿using CCL.Types.Components;
+﻿using CCL.Types;
 using DV.ThingTypes;
 using System.Collections;
 using UnityEngine;
@@ -27,7 +27,7 @@ namespace CCL.Importer.Components
             var car = GetComponent<TrainCar>();
             _coupler = Direction == CouplerDirection.Front ? car.frontCoupler : car.rearCoupler;
 
-            if (_coupler == null)
+            if (!_coupler)
             {
                 Debug.LogError("CarAutoCoupler couldn't find Coupler component during init", this);
                 yield break;

--- a/CCL.Importer/Components/CarAutoCouplerInternal.cs
+++ b/CCL.Importer/Components/CarAutoCouplerInternal.cs
@@ -25,7 +25,7 @@ namespace CCL.Importer.Components
         private IEnumerator Start()
         {
             var car = GetComponent<TrainCar>();
-            _coupler = Direction == CouplerDirection.Front ? car.frontCoupler : car.rearCoupler;
+            _coupler = Direction.IsFront() ? car.frontCoupler : car.rearCoupler;
 
             if (!_coupler)
             {
@@ -78,7 +78,7 @@ namespace CCL.Importer.Components
                 if (firstCouplerInRange != null && !firstCouplerInRange.IsCoupled())
                 {
                     var car = firstCouplerInRange.train;
-                    var otherCoupler = OtherDirection == CouplerDirection.Front ? car.frontCoupler : car.rearCoupler;
+                    var otherCoupler = OtherDirection.IsFront() ? car.frontCoupler : car.rearCoupler;
                     if (!car.derailed && MeetsConditions(car.carLivery) && otherCoupler == firstCouplerInRange)
                     {
                         _coupler.TryCouple(true, false, AUTOCOUPLE_RANGE);

--- a/CCL.Importer/Components/CustomComponentReplacer.cs
+++ b/CCL.Importer/Components/CustomComponentReplacer.cs
@@ -8,6 +8,7 @@ namespace CCL.Importer.Components
         public CustomComponentReplacer()
         {
             CreateMap<CarAutoCoupler, CarAutoCouplerInternal>().AutoCacheAndMap();
+            CreateMap<RigidCoupler, RigidCouplerInternal>().AutoCacheAndMap();
         }
     }
 }

--- a/CCL.Importer/Components/CustomComponentReplacer.cs
+++ b/CCL.Importer/Components/CustomComponentReplacer.cs
@@ -9,6 +9,7 @@ namespace CCL.Importer.Components
         {
             CreateMap<CarAutoCoupler, CarAutoCouplerInternal>().AutoCacheAndMap();
             CreateMap<RigidCoupler, RigidCouplerInternal>().AutoCacheAndMap();
+            CreateMap<VirtualHandbrakeOverrider, VirtualHandbrakeOverriderInternal>().AutoCacheAndMap();
         }
     }
 }

--- a/CCL.Importer/Components/CustomComponentReplacer.cs
+++ b/CCL.Importer/Components/CustomComponentReplacer.cs
@@ -10,6 +10,7 @@ namespace CCL.Importer.Components
             CreateMap<CarAutoCoupler, CarAutoCouplerInternal>().AutoCacheAndMap();
             CreateMap<RigidCoupler, RigidCouplerInternal>().AutoCacheAndMap();
             CreateMap<VirtualHandbrakeOverrider, VirtualHandbrakeOverriderInternal>().AutoCacheAndMap();
+            CreateMap<DuplicateHandbrakeOverrider, DuplicateHandbrakeOverriderInternal>().AutoCacheAndMap();
         }
     }
 }

--- a/CCL.Importer/Components/CustomComponentReplacer.cs
+++ b/CCL.Importer/Components/CustomComponentReplacer.cs
@@ -1,0 +1,13 @@
+﻿using AutoMapper;
+using CCL.Types.Components;
+
+namespace CCL.Importer.Components
+{
+    internal class CustomComponentReplacer : Profile
+    {
+        public CustomComponentReplacer()
+        {
+            CreateMap<CarAutoCoupler, CarAutoCouplerInternal>().AutoCacheAndMap();
+        }
+    }
+}

--- a/CCL.Importer/Components/DuplicateHandbrakeOverriderInternal.cs
+++ b/CCL.Importer/Components/DuplicateHandbrakeOverriderInternal.cs
@@ -1,0 +1,24 @@
+﻿using CCL.Importer.Implementations;
+using CCL.Types;
+using DV.Simulation.Cars;
+using DV.Simulation.Controllers;
+using UnityEngine;
+
+namespace CCL.Importer.Components
+{
+    internal class DuplicateHandbrakeOverriderInternal : MonoBehaviour, BaseControlsOverrider.IHandbrakeOverrider
+    {
+        public CouplerDirection Direction;
+
+        public bool AlwaysCopy = false;
+        [CarKindField]
+        public string[] CarKinds = new string[0];
+        public string[] CarTypes = new string[0];
+        public string[] CarLiveries = new string[0];
+
+        public HandbrakeControl GetHandbrake(TrainCar car)
+        {
+            return new DuplicateHandbrake(car, this);
+        }
+    }
+}

--- a/CCL.Importer/Components/RigidCouplerInternal.cs
+++ b/CCL.Importer/Components/RigidCouplerInternal.cs
@@ -1,0 +1,118 @@
+﻿using CCL.Types;
+using DV.ThingTypes;
+using System.Collections;
+using UnityEngine;
+
+namespace CCL.Importer.Components
+{
+    internal class RigidCouplerInternal : MonoBehaviour
+    {
+        private Coupler _coupler = null!;
+        private Coroutine? _enstrongCoro;
+
+        public CouplerDirection Direction;
+        public bool AlwaysRigid = false;
+        public string[] CarKinds = new string[0];
+        public string[] CarTypes = new string[0];
+        public string[] CarLiveries = new string[0];
+
+        private void Start()
+        {
+            _coupler = transform.Find(Direction == CouplerDirection.Front ? "[coupler front]" : "[coupler rear]").GetComponent<Coupler>();
+
+            if (!_coupler)
+            {
+                Debug.LogError("RigidCouplerInternal couldn't find Coupler component during init", this);
+                return;
+            }
+
+            SetupListeners(true);
+        }
+
+        private void SetupListeners(bool on)
+        {
+            if (on)
+            {
+                _coupler.Coupled += OnCoupled;
+                _coupler.Uncoupled += OnUncouple;
+            }
+            else
+            {
+                _coupler.Coupled -= OnCoupled;
+                _coupler.Uncoupled -= OnUncouple;
+            }
+        }
+
+        private void OnUncouple(object _, UncoupleEventArgs e)
+        {
+            if (_enstrongCoro != null)
+            {
+                StopCoroutine(_enstrongCoro);
+            }
+
+            _enstrongCoro = null;
+        }
+
+        private void OnCoupled(object _, CoupleEventArgs e)
+        {
+            if (MeetsConditions(e.otherCoupler.train.carLivery))
+            {
+                Coupler coupler = (e.thisCoupler.rigidCJ != null) ? e.thisCoupler : e.otherCoupler;
+
+                if (coupler == null)
+                {
+                    Debug.LogError("RigidCouplerInternal couldn't find Coupler component during coupling", this);
+                    return;
+                }
+
+                if (coupler.rigidCJ == null)
+                {
+                    Debug.LogError("RigidCouplerInternal couldn't find the ConfigurableJoint during coupling", this);
+                    return;
+                }
+
+                if (_enstrongCoro != null)
+                {
+                    StopCoroutine(_enstrongCoro);
+                }
+                
+                _enstrongCoro = StartCoroutine(EnstrongJoints(coupler));
+            }
+        }
+
+        private IEnumerator EnstrongJoints(Coupler coupler)
+        {
+            while (coupler.IsJointAdaptationActive)
+            {
+                yield return WaitFor.Seconds(0.5f);
+            }
+
+            coupler.rigidCJ.xMotion = ConfigurableJointMotion.Locked;
+            coupler.rigidCJ.yMotion = ConfigurableJointMotion.Locked;
+            coupler.rigidCJ.zMotion = ConfigurableJointMotion.Locked;
+            coupler.rigidCJ.autoConfigureConnectedAnchor = true;
+        }
+
+        private bool MeetsConditions(TrainCarLivery car)
+        {
+            if (AlwaysRigid) return true;
+
+            foreach (var item in CarKinds)
+            {
+                if (car.parentType.kind.id == item) return true;
+            }
+
+            foreach (var item in CarTypes)
+            {
+                if (car.parentType.id == item) return true;
+            }
+
+            foreach (var item in CarLiveries)
+            {
+                if (car.id == item) return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/CCL.Importer/Components/RigidCouplerInternal.cs
+++ b/CCL.Importer/Components/RigidCouplerInternal.cs
@@ -18,7 +18,7 @@ namespace CCL.Importer.Components
 
         private void Start()
         {
-            _coupler = transform.Find(Direction == CouplerDirection.Front ? "[coupler front]" : "[coupler rear]").GetComponent<Coupler>();
+            _coupler = transform.Find(Direction.IsFront() ? "[coupler front]" : "[coupler rear]").GetComponent<Coupler>();
 
             if (!_coupler)
             {

--- a/CCL.Importer/Components/VirtualHandbrakeOverriderInternal.cs
+++ b/CCL.Importer/Components/VirtualHandbrakeOverriderInternal.cs
@@ -1,0 +1,23 @@
+﻿using CCL.Importer.Implementations;
+using CCL.Types;
+using DV.Simulation.Cars;
+using DV.Simulation.Controllers;
+using UnityEngine;
+
+namespace CCL.Importer.Components
+{
+    internal class VirtualHandbrakeOverriderInternal : MonoBehaviour, BaseControlsOverrider.IHandbrakeOverrider
+    {
+        public CouplerDirection Direction;
+
+        public bool AlwaysCopy = false;
+        public string[] CarKinds = new string[0];
+        public string[] CarTypes = new string[0];
+        public string[] CarLiveries = new string[0];
+
+        public HandbrakeControl GetHandbrake(TrainCar car)
+        {
+            return new VirtualHandbrake(car, this);
+        }
+    }
+}

--- a/CCL.Importer/Extensions.cs
+++ b/CCL.Importer/Extensions.cs
@@ -236,5 +236,10 @@ namespace CCL.Importer
         {
             return ((TrainCarType)buffer).ToV2().prefab;
         }
+
+        public static bool IsFront(this CouplerDirection direction)
+        {
+            return direction == CouplerDirection.Front;
+        }
     }
 }

--- a/CCL.Importer/Implementations/VirtualHandbrake.cs
+++ b/CCL.Importer/Implementations/VirtualHandbrake.cs
@@ -1,0 +1,85 @@
+﻿using CCL.Importer.Components;
+using DV.Simulation.Controllers;
+using DV.ThingTypes;
+
+namespace CCL.Importer.Implementations
+{
+    internal class VirtualHandbrake : HandbrakeControl
+    {
+        private TrainCar? _coupled;
+        private VirtualHandbrakeOverriderInternal _overrider;
+
+        public override float Value => _coupled != null ? _coupled.brakeSystem.handbrakePosition : 0f;
+
+        protected override bool canExistWithoutHandbrake => true;
+
+        public VirtualHandbrake(TrainCar car, VirtualHandbrakeOverriderInternal overrider) : base(car)
+        {
+            _overrider = overrider;
+
+            var coupler = overrider.Direction.IsFront() ? car.frontCoupler : car.rearCoupler;
+
+            coupler.Coupled += OnCoupled;
+            coupler.Uncoupled += OnUncoupled;
+
+            if (coupler.coupledTo)
+            {
+                OnCoupled(this, new CoupleEventArgs(coupler, coupler.coupledTo, false));
+            }
+        }
+
+        public override void Set(float value)
+        {
+            if (_coupled == null) return;
+
+            _coupled.brakeSystem.SetHandbrakePosition(value, true);
+        }
+
+        private void OnUncoupled(object sender, UncoupleEventArgs e)
+        {
+            if (!e.otherCoupler)
+            {
+                return;
+            }
+
+            if (MeetsConditions(e.otherCoupler.train.carLivery) && _coupled == e.otherCoupler.train)
+            {
+                _coupled.brakeSystem.HandbrakePositionChanged -= OnControlUpdated;
+                _coupled = null;
+            }
+        }
+
+        private void OnCoupled(object sender, CoupleEventArgs e)
+        {
+            if (!e.otherCoupler) return;
+
+            if (MeetsConditions(e.otherCoupler.train.carLivery))
+            {
+                _coupled = e.otherCoupler.train;
+                _coupled.brakeSystem.HandbrakePositionChanged += OnControlUpdated;
+            }
+        }
+
+        private bool MeetsConditions(TrainCarLivery car)
+        {
+            if (_overrider.AlwaysCopy) return true;
+
+            foreach (var item in _overrider.CarKinds)
+            {
+                if (car.parentType.kind.id == item) return true;
+            }
+
+            foreach (var item in _overrider.CarTypes)
+            {
+                if (car.parentType.id == item) return true;
+            }
+
+            foreach (var item in _overrider.CarLiveries)
+            {
+                if (car.id == item) return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/CCL.Importer/Processing/ExternalInteractableProcessor.cs
+++ b/CCL.Importer/Processing/ExternalInteractableProcessor.cs
@@ -66,6 +66,12 @@ namespace CCL.Importer.Processing
                 var brakeFeeders = interactables.AddComponent<HandbrakeFeedersController>();
                 brakeFeeders.RefreshChildren();
 
+                // Car has no handbrakes, delete controller.
+                if (brakeFeeders.entries.Length == 0)
+                {
+                    Object.Destroy(brakeFeeders);
+                }
+
                 var keyboardCtrl = interactables.AddComponent<InteractablesKeyboardControl>();
                 keyboardCtrl.RefreshChildren();
 

--- a/CCL.Types/Components/CarAutoCoupler.cs
+++ b/CCL.Types/Components/CarAutoCoupler.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Components
+{
+    public enum CouplerDirection
+    {
+        Front,
+        Rear
+    }
+
+    public class CarAutoCoupler : MonoBehaviour
+    {
+        public CouplerDirection Direction;
+
+        public bool AlwaysCouple = false;
+        [CarKindField]
+        public string[] CarKinds = new string[0];
+        public string[] CarTypes = new string[0];
+        public string[] CarLiveries = new string[0];
+    }
+}

--- a/CCL.Types/Components/CarAutoCoupler.cs
+++ b/CCL.Types/Components/CarAutoCoupler.cs
@@ -10,7 +10,10 @@ namespace CCL.Types.Components
 
     public class CarAutoCoupler : MonoBehaviour
     {
+        [Tooltip("The coupler of this car to connect")]
         public CouplerDirection Direction;
+        [Tooltip("The coupler of the other car to connect")]
+        public CouplerDirection OtherDirection;
 
         public bool AlwaysCouple = false;
         [CarKindField]

--- a/CCL.Types/Components/DuplicateHandbrakeOverrider.cs
+++ b/CCL.Types/Components/DuplicateHandbrakeOverrider.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Components
+{
+    [DisallowMultipleComponent]
+    public class DuplicateHandbrakeOverrider : MonoBehaviour
+    {
+        public CouplerDirection Direction;
+
+        public bool AlwaysCopy = false;
+        [CarKindField]
+        public string[] CarKinds = new string[0];
+        public string[] CarTypes = new string[0];
+        public string[] CarLiveries = new string[0];
+    }
+}

--- a/CCL.Types/Components/RigidCoupler.cs
+++ b/CCL.Types/Components/RigidCoupler.cs
@@ -2,14 +2,11 @@
 
 namespace CCL.Types.Components
 {
-    public class CarAutoCoupler : MonoBehaviour
+    public class RigidCoupler : MonoBehaviour
     {
-        [Tooltip("The coupler of this car to connect")]
         public CouplerDirection Direction;
-        [Tooltip("The coupler of the other car to connect")]
-        public CouplerDirection OtherDirection;
 
-        public bool AlwaysCouple = false;
+        public bool AlwaysRigid = false;
         [CarKindField]
         public string[] CarKinds = new string[0];
         public string[] CarTypes = new string[0];

--- a/CCL.Types/Components/VirtualHandbrakeOverrider.cs
+++ b/CCL.Types/Components/VirtualHandbrakeOverrider.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Components
+{
+    [DisallowMultipleComponent]
+    public class VirtualHandbrakeOverrider : MonoBehaviour
+    {
+        public CouplerDirection Direction;
+
+        public bool AlwaysCopy = false;
+        [CarKindField]
+        public string[] CarKinds = new string[0];
+        public string[] CarTypes = new string[0];
+        public string[] CarLiveries = new string[0];
+    }
+}

--- a/CCL.Types/IdV2.cs
+++ b/CCL.Types/IdV2.cs
@@ -1,4 +1,6 @@
-﻿namespace CCL.Types
+﻿using System;
+
+namespace CCL.Types
 {
     public static class IdV2
     {
@@ -251,5 +253,16 @@
             "Relic",
             "Relic_Rusty",
         };
+
+        public static string[] AllLicenses
+        {
+            get
+            {
+                var all = new string[GeneralLicenses.Length + JobLicenses.Length];
+                GeneralLicenses.CopyTo(all, 0);
+                JobLicenses.CopyTo(all, GeneralLicenses.Length);
+                return all;
+            }
+        }
     }
 }

--- a/CCL.Types/IdV2.cs
+++ b/CCL.Types/IdV2.cs
@@ -2,7 +2,103 @@
 {
     public static class IdV2
     {
-        // Last update: b98
+        // ============
+        // Last update:
+        // B99.3
+        // ============
+
+        public static readonly string[] CarKinds =
+        {
+            "Car",
+            "Loco",
+            "Tender",
+            "Slug",
+            "Caboose",
+        };
+        public static readonly string[] CarTypes =
+        {
+            "Autorack",
+            "Boxcar",
+            "BoxcarMilitary",
+            "Caboose",
+            "Flatbed",
+            "FlatbedMilitary",
+            "FlatbedStakes",
+            "FlatbedShort",
+            "Gondola",
+            "HandCar",
+            "Hopper",
+            "HopperCovered",
+            "LocoDE2",
+            "LocoDE6",
+            "LocoDE6Slug",
+            "LocoDH4",
+            "LocoDM3",
+            "LocoS282A",
+            "LocoS282B",
+            "LocoS060",
+            "NuclearFlask",
+            "Passenger",
+            "Stock",
+            "Refrigerator",
+            "TankChem",
+            "TankGas",
+            "TankOil",
+            "TankShortFood",
+            "LocoMicroshunter",
+            "LocoDM1U"
+        };
+        public static readonly string[] CarLiveries =
+        {
+            "LocoDE2",
+            "LocoS282A",
+            "LocoS282B",
+            "LocoS060",
+            "LocoDM1U",
+            "LocoDE6",
+            "LocoDE6Slug",
+            "LocoDH4",
+            "LocoDM3",
+            "LocoMicroshunter",
+            "FlatbedEmpty",
+            "FlatbedStakes",
+            "FlatbedMilitary",
+            "FlatbedShort",
+            "AutorackRed",
+            "AutorackBlue",
+            "AutorackGreen",
+            "AutorackYellow",
+            "TankOrange",
+            "TankWhite",
+            "TankYellow",
+            "TankBlue",
+            "TankChrome",
+            "TankBlack",
+            "TankShortMilk",
+            "StockRed",
+            "StockGreen",
+            "StockBrown",
+            "BoxcarBrown",
+            "BoxcarGreen",
+            "BoxcarPink",
+            "BoxcarRed",
+            "BoxcarMilitary",
+            "RefrigeratorWhite",
+            "HopperBrown",
+            "HopperTeal",
+            "HopperYellow",
+            "HopperCoveredBrown",
+            "GondolaRed",
+            "GondolaGreen",
+            "GondolaGray",
+            "PassengerRed",
+            "PassengerGreen",
+            "PassengerBlue",
+            "HandCar",
+            "CabooseRed",
+            "NuclearFlask"
+        };
+
         public static readonly string[] Cargos =
         {
             "Coal",
@@ -14,31 +110,38 @@
             "Logs",
             "Boards",
             "Plywood",
+            "RailwaySleepers",
             "Wheat",
             "Corn",
             "SunflowerSeeds",
+            "Flour",
             "Pigs",
             "Cows",
             "Poultry",
             "Sheep",
             "Goats",
+            "Fish",
             "Bread",
             "DairyProducts",
             "MeatProducts",
             "CannedFood",
             "CatFood",
-            "LocalFruits",
+            "TemperateFruits",
             "Vegetables",
             "Milk",
             "Eggs",
             "Cotton",
             "Wool",
+            "TropicalFruits",
             "SteelRolls",
             "SteelBillets",
             "SteelSlabs",
             "SteelBentPlates",
             "SteelRails",
             "ScrapMetal",
+            "WoodScrap",
+            "WoodChips",
+            "ScrapContainers",
             "ElectronicsIskar",
             "ElectronicsKrugmann",
             "ElectronicsAAG",
@@ -62,6 +165,12 @@
             "ImportedNewCars",
             "Tractors",
             "Excavators",
+            "MiningTrucks",
+            "CityBuses",
+            "SemiTrailers",
+            "CraneParts",
+            "Trams",
+            "ForestryTrailers",
             "Alcohol",
             "Acetylene",
             "CryoOxygen",
@@ -70,12 +179,22 @@
             "Nitrogen",
             "Ammonia",
             "SodiumHydroxide",
+            "AmmoniumNitrate",
             "SpentNuclearFuel",
             "Ammunition",
             "Biohazard",
             "Tanks",
             "MilitaryTrucks",
             "MilitarySupplies",
+            "AttackHelicopsters",
+            "Missiles",
+            "MilitaryCars",
+            "TrainPartsDE2",
+            "TrainPartsDE6",
+            "TrainPartsDH4",
+            "TrainPartsDM3",
+            "TrainPartsS060",
+            "TrainPartsS282A",
             "EmptySunOmni",
             "EmptyIskar",
             "EmptyObco",
@@ -89,6 +208,7 @@
             "EmptyChemlek",
             "EmptyNeoGamma"
         };
+
         public static readonly string[] GeneralLicenses =
         {
             "TrainDriver",
@@ -121,6 +241,7 @@
             "TrainLength1",
             "TrainLength2"
         };
+
         // Not really an ID but oh well.
         public static readonly string[] Paints =
         {

--- a/CCL.Types/OtherEnums.cs
+++ b/CCL.Types/OtherEnums.cs
@@ -1,0 +1,8 @@
+﻿namespace CCL.Types
+{
+    public enum CouplerDirection
+    {
+        Front,
+        Rear
+    }
+}

--- a/CCL.Types/Proxies/Simulation/Electric/VoltageRegulatorDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/Electric/VoltageRegulatorDefinitionProxy.cs
@@ -6,7 +6,7 @@ namespace CCL.Types.Proxies.Simulation.Electric
     public class VoltageRegulatorDefinitionProxy : SimComponentDefinitionProxy
     {
         public override IEnumerable<PortDefinition> ExposedPorts => new[]
-{
+        {
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.VOLTS, "OUTPUT_VOLTAGE"),
             new PortDefinition(DVPortType.EXTERNAL_IN, DVPortValueType.AMPS, "EXTERNAL_CURRENT_LIMIT_EXT_IN"),
             new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.STATE, "EXTERNAL_CURRENT_LIMIT_ACTIVE")

--- a/CCL.Types/StringAndSelectorFieldAttribute.cs
+++ b/CCL.Types/StringAndSelectorFieldAttribute.cs
@@ -49,4 +49,9 @@ namespace CCL.Types
     {
         public PaintFieldAttribute(bool customAllowed = true) : base(IdV2.Paints, customAllowed) { }
     }
+
+    public class CarKindFieldAttribute : StringAndSelectorFieldAttribute
+    {
+        public CarKindFieldAttribute() : base(IdV2.CarKinds, false) { }
+    }
 }


### PR DESCRIPTION
Added a generic autocoupler.
* Will couple 2 vehicles automatically if they're close depending on conditions (specific car kind(s), car type(s) or car livery/liveries).
* As such, a proxy version of the S282's tender version is not included with CCL.

Added coupler rigidifier.
* Locks the joint positions of a coupler depending on conditions (see above).
* Once again, no proxy version of the original S282A-S282B version (also see above).

Added a virtual handbrake.
* Copies the handbrake of a coupled vehicle, for a vehicle without handbrakes, depending on conditions (see above).
* No proxy version once again.

Added a duplicate handbrake.
* Functions as both a virtual handbrake, copying the main handbrake, but also allows the vehicle to have its own handbrake.

Improved StringAndSelectorField editor (less code duplication for children).