### PR TITLE
Headlights

### DIFF
--- a/CCL.Creator/Utility/EditorHelpers.cs
+++ b/CCL.Creator/Utility/EditorHelpers.cs
@@ -331,6 +331,38 @@ namespace CCL.Creator.Utility
                 }
             };
         }
+
+        public static bool DrawStringArray(string label, ref string[] array, bool expanded)
+        {
+            return DrawStringArray(new GUIContent(label), ref array, expanded);
+        }
+
+        public static bool DrawStringArray(string label, string tooltip, ref string[] array, bool expanded)
+        {
+            return DrawStringArray(new GUIContent(label, tooltip), ref array, expanded);
+        }
+
+        public static bool DrawStringArray(GUIContent label, ref string[] array, bool expanded)
+        {
+            expanded = EditorGUILayout.Foldout(expanded, label);
+
+            if (expanded)
+            {
+                int size = Mathf.Max(0, EditorGUILayout.DelayedIntField("Size", array.Length));
+
+                if (array.Length != size)
+                {
+                    Array.Resize(ref array, size);
+                }
+
+                for (int i = 0; i < size; i++)
+                {
+                    array[i] = EditorGUILayout.TextField($"Item {i}", array[i]);
+                }
+            }
+
+            return expanded;
+        }
     }
 
     internal class GUIColorScope : IDisposable

--- a/CCL.Creator/Wizards/HeadlightWizard.cs
+++ b/CCL.Creator/Wizards/HeadlightWizard.cs
@@ -1,0 +1,307 @@
+﻿using CCL.Creator.Utility;
+using CCL.Types.Components;
+using CCL.Types.Proxies.Headlights;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace CCL.Creator.Wizards
+{
+    internal class HeadlightWizard : EditorWindow
+    {
+        private class Settings
+        {
+            public string[] WhiteNames = new string[0];
+            public string[] RedNames = new string[0];
+        }
+
+        private enum LightType
+        {
+            High,
+            Low,
+            Red
+        }
+
+        private static HeadlightWizard? s_instance;
+
+        public GameObject TargetObject = null!;
+
+        private Settings _settingsR = null!;
+        private Settings _settingsF = null!;
+
+        [MenuItem("GameObject/CCL/Create Headlights", false, 10)]
+        public static void ShowWindow(MenuCommand command)
+        {
+            s_instance = GetWindow<HeadlightWizard>();
+
+            s_instance._settingsF = new Settings();
+            s_instance._settingsR = new Settings();
+            s_instance.TargetObject = (GameObject)command.context;
+            s_instance.titleContent = new GUIContent("CCL - Headlight Wizard");
+            s_instance.Show();
+        }
+
+        [MenuItem("GameObject/CCL/Create Headlights", true, 10)]
+        public static bool OnContextMenuValidate()
+        {
+            return Selection.activeGameObject;
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.BeginVertical("box");
+            EditorStyles.label.wordWrap = true;
+
+            EditorHelpers.DrawHeader("Front Lights");
+            EditorHelpers.DrawStringArray("White Light Names", ref _settingsF.WhiteNames, true);
+            EditorHelpers.DrawStringArray("Red Light Names", ref _settingsF.RedNames, true);
+
+            if (GUILayout.Button("Copy Front Lights To Rear"))
+            {
+                _settingsR.WhiteNames = _settingsF.WhiteNames;
+                _settingsR.RedNames = _settingsF.RedNames;
+            }
+
+            EditorHelpers.DrawHeader("Rear Lights");
+            EditorHelpers.DrawStringArray("White Light Names", ref _settingsR.WhiteNames, true);
+            EditorHelpers.DrawStringArray("Red Light Names", ref _settingsR.RedNames, true);
+
+            EditorGUILayout.Space(18);
+
+            if (GUILayout.Button("Create"))
+            {
+                CreateTemplate();
+                return;
+            }
+
+            EditorGUILayout.EndVertical();
+        }
+
+        private void CreateTemplate()
+        {
+            var root = new GameObject("[headlights]");
+            root.transform.parent = TargetObject.transform;
+            root.transform.localPosition = Vector3.zero;
+            root.transform.localRotation = Quaternion.identity;
+
+            int whiteF = _settingsF.WhiteNames.Length;
+            int redF = _settingsF.RedNames.Length;
+            int whiteR = _settingsR.WhiteNames.Length;
+            int redR = _settingsR.RedNames.Length;
+
+            var main = root.AddComponent<HeadlightsMainControllerProxy>();
+            var opti = root.AddComponent<CarLightsOptimizerProxy>();
+
+            if (whiteF > 0 || whiteR > 0)
+            {
+                var beam = root.AddComponent<HeadlightBeamControllerProxy>();
+                beam.headlightsMainController = main;
+                opti.beamController = beam;
+            }
+
+            var front = new GameObject("FrontSide").transform;
+            front.parent = root.transform;
+            front.localPosition = Vector3.zero;
+            front.localRotation = Quaternion.identity;
+
+            main.headlightSetupsFront = new HeadlightSetup[6];
+
+            for (int i = 0; i < 6; i++)
+            {
+                main.headlightSetupsFront[i] = front.gameObject.AddComponent<HeadlightSetup>();
+            }
+
+            var rear = new GameObject("RearSide").transform;
+            rear.parent = root.transform;
+            rear.localPosition = Vector3.zero;
+            rear.localRotation = Quaternion.identity;
+
+            main.headlightSetupsRear = new HeadlightSetup[6];
+
+            for (int i = 0; i < 6; i++)
+            {
+                main.headlightSetupsRear[i] = rear.gameObject.AddComponent<HeadlightSetup>();
+            }
+
+            main.headlightSetupsFront[2].mainOffSetup = true;
+            main.headlightSetupsRear[2].mainOffSetup = true;
+
+            if (whiteF > 0)
+            {
+                var subControllerParent = GetSubControllerTransform(front.transform);
+
+                List<HeadlightProxy> highs = new List<HeadlightProxy>();
+                List<HeadlightProxy> lows = new List<HeadlightProxy>();
+
+                foreach (var item in _settingsF.WhiteNames)
+                {
+                    highs.Add(CreateHeadlight(front.transform, LightType.High, item));
+                    lows.Add(CreateHeadlight(front.transform, LightType.Low, item));
+                }
+
+                var highController = AddSubController(subControllerParent, "WhiteHigh", true);
+                highController.headlights = highs.ToArray();
+                var lowController = AddSubController(subControllerParent, "WhiteLow", true);
+                lowController.headlights = lows.ToArray();
+
+                var light = new GameObject("LightHigh").AddComponent<Light>();
+                light.transform.parent = front.transform;
+                light.transform.localPosition = Vector3.zero;
+                light.transform.localEulerAngles = new Vector3(1, 0, 0);
+                highController.lightSources = new[] { light };
+                CopyVanillaLight.ApplyProperties(light, VanillaLight.LocoHeadlightsHigh);
+
+                light = new GameObject("LightLow").AddComponent<Light>();
+                light.transform.parent = front.transform;
+                light.transform.localPosition = Vector3.zero;
+                light.transform.localEulerAngles = new Vector3(8, 0, 0);
+                lowController.lightSources = new[] { light };
+                CopyVanillaLight.ApplyProperties(light, VanillaLight.LocoHeadlightsLow);
+
+                main.headlightSetupsFront[5].subControllers = new[] { highController };
+                main.headlightSetupsFront[5].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting03;
+                main.headlightSetupsFront[4].subControllers = new[] { lowController };
+                main.headlightSetupsFront[4].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting02;
+                main.headlightSetupsFront[3].subControllers = new[] { lowController };
+                main.headlightSetupsFront[3].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting01;
+            }
+
+            if (redF > 0)
+            {
+                var subControllerParent = GetSubControllerTransform(front.transform);
+
+                List<HeadlightProxy> reds = new List<HeadlightProxy>();
+
+                foreach (var item in _settingsF.RedNames)
+                {
+                    reds.Add(CreateHeadlight(front.transform, LightType.Red, item));
+                }
+
+                var controller = AddSubController(subControllerParent, "Red", true);
+                controller.headlights = reds.ToArray();
+
+                main.headlightSetupsFront[0].subControllers = new[] { controller };
+                main.headlightSetupsFront[0].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting02;
+                main.headlightSetupsFront[1].subControllers = new[] { controller };
+                main.headlightSetupsFront[1].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting01;
+            }
+
+            if (whiteR > 0)
+            {
+                var subControllerParent = GetSubControllerTransform(rear.transform);
+
+                List<HeadlightProxy> highs = new List<HeadlightProxy>();
+                List<HeadlightProxy> lows = new List<HeadlightProxy>();
+
+                foreach (var item in _settingsR.WhiteNames)
+                {
+                    highs.Add(CreateHeadlight(rear.transform, LightType.High, item));
+                    lows.Add(CreateHeadlight(rear.transform, LightType.Low, item));
+                }
+
+                var highController = AddSubController(subControllerParent, "WhiteHigh", false);
+                highController.headlights = highs.ToArray();
+                var lowController = AddSubController(subControllerParent, "WhiteLow", false);
+                lowController.headlights = lows.ToArray();
+
+                var light = new GameObject("LightHigh").AddComponent<Light>();
+                light.transform.parent = rear.transform;
+                light.transform.localPosition = Vector3.zero;
+                light.transform.localEulerAngles = new Vector3(1, 0, 0);
+                highController.lightSources = new[] { light };
+                CopyVanillaLight.ApplyProperties(light, VanillaLight.LocoHeadlightsHigh);
+
+                light = new GameObject("LightLow").AddComponent<Light>();
+                light.transform.parent = rear.transform;
+                light.transform.localPosition = Vector3.zero;
+                light.transform.localEulerAngles = new Vector3(8, 0, 0);
+                lowController.lightSources = new[] { light };
+                CopyVanillaLight.ApplyProperties(light, VanillaLight.LocoHeadlightsLow);
+
+                main.headlightSetupsRear[5].subControllers = new[] { highController };
+                main.headlightSetupsRear[5].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting03;
+                main.headlightSetupsRear[4].subControllers = new[] { lowController };
+                main.headlightSetupsRear[4].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting02;
+                main.headlightSetupsRear[3].subControllers = new[] { lowController };
+                main.headlightSetupsRear[3].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting01;
+            }
+
+            if (redR > 0)
+            {
+                var subControllerParent = GetSubControllerTransform(rear.transform);
+
+                List<HeadlightProxy> reds = new List<HeadlightProxy>();
+
+                foreach (var item in _settingsR.RedNames)
+                {
+                    reds.Add(CreateHeadlight(rear.transform, LightType.Red, item));
+                }
+
+                var controller = AddSubController(subControllerParent, "Red", false);
+                controller.headlights = reds.ToArray();
+
+                main.headlightSetupsRear[0].subControllers = new[] { controller };
+                main.headlightSetupsRear[0].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting02;
+                main.headlightSetupsRear[1].subControllers = new[] { controller };
+                main.headlightSetupsRear[1].setting = HeadlightSetup.HeadlightSetting.HeadlightSetting01;
+            }
+
+            AssetHelper.SaveAsset(root);
+            return;
+        }
+
+        private static Transform GetSubControllerTransform(Transform parent)
+        {
+            var t = parent.Find("SubControllers");
+
+            if (t == null)
+            {
+                t = new GameObject("SubControllers").transform;
+                t.parent = parent;
+                t.localPosition = Vector3.zero;
+                t.localRotation = Quaternion.identity;
+            }
+
+            return t;
+        }
+
+        private static HeadlightProxy CreateHeadlight(Transform parent, LightType type, string name)
+        {
+            var light = new GameObject($"Headlights{name}{GetName(type)}").AddComponent<HeadlightProxy>();
+            light.transform.parent = parent;
+            light.transform.localPosition = Vector3.zero;
+            light.transform.localRotation = Quaternion.identity;
+
+            return light;
+
+            static string GetName(LightType type) => type switch
+            {
+                LightType.High => "High",
+                LightType.Low => "Low",
+                LightType.Red => "Red",
+                _ => string.Empty,
+            };
+        }
+
+        private static HeadlightsSubControllerStandardProxy AddSubController(Transform parent, string name, bool front)
+        {
+            var controller = new GameObject(name).AddComponent<HeadlightsSubControllerStandardProxy>();
+            controller.transform.parent = parent;
+            controller.transform.localPosition = Vector3.zero;
+            controller.transform.localRotation = Quaternion.identity;
+
+            if (front)
+            {
+                controller.isFront = true;
+                controller.multipleUnityDependent = HeadlightsSubControllerBaseProxy.HeadlightMUDependency.Front;
+            }
+            else
+            {
+                controller.isFront = false;
+                controller.multipleUnityDependent = HeadlightsSubControllerBaseProxy.HeadlightMUDependency.Rear;
+            }
+
+            return controller;
+        }
+    }
+}

--- a/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/DieselElectricSimCreator.cs
@@ -45,8 +45,8 @@ namespace CCL.Creator.Wizards.SimSetup
             var horn = CreateSimComponent<HornDefinitionProxy>("horn");
             horn.controlNeutralAt0 = true;
 
-            ExternalControlDefinitionProxy bellControl = null!;
-            ElectricBellDefinitionProxy bell = null!;
+            ExternalControlDefinitionProxy? bellControl = null;
+            ElectricBellDefinitionProxy? bell = null;
 
             if (HasBell(basisIndex))
             {
@@ -155,7 +155,7 @@ namespace CCL.Creator.Wizards.SimSetup
             ConnectPortRef(thrtPowr, "MAX_POWER", engine, "MAX_POWER");
 
             ConnectPortRef(horn, "HORN_CONTROL", genericHornControl, "CONTROL");
-            if (bell != null)
+            if (bell != null && bellControl != null)
             {
                 ConnectPortRef(bell, "CONTROL", bellControl, "EXT_IN");
             }

--- a/CCL.Creator/Wizards/SimSetup/TenderSimCreator.cs
+++ b/CCL.Creator/Wizards/SimSetup/TenderSimCreator.cs
@@ -30,6 +30,8 @@ namespace CCL.Creator.Wizards.SimSetup
 
             var dynamo = CreateSimComponent<ConstantPortDefinitionProxy>("dynamoFlowDummy");
             dynamo.port.ID = "DYNAMO_FLOW_NORMALIZED";
+            dynamo.port.type = DVPortType.READONLY_OUT;
+            dynamo.port.valueType = DVPortValueType.STATE;
             CreateBroadcastConsumer(dynamo, dynamo.port.ID, DVPortForwardConnectionType.COUPLED_FRONT, "DYNAMO_FLOW", 0, false);
 
             var fuseController = CreateSimComponent<FuseControllerDefinitionProxy>("electronicsFuseControllerDummy");

--- a/CCL.Importer/Components/CustomComponentReplacer.cs
+++ b/CCL.Importer/Components/CustomComponentReplacer.cs
@@ -1,5 +1,7 @@
 ﻿using AutoMapper;
+using CCL.Importer.Components.Headlights;
 using CCL.Types.Components;
+using CCL.Types.Components.Headlights;
 
 namespace CCL.Importer.Components
 {
@@ -11,6 +13,14 @@ namespace CCL.Importer.Components
             CreateMap<RigidCoupler, RigidCouplerInternal>().AutoCacheAndMap();
             CreateMap<VirtualHandbrakeOverrider, VirtualHandbrakeOverriderInternal>().AutoCacheAndMap();
             CreateMap<DuplicateHandbrakeOverrider, DuplicateHandbrakeOverriderInternal>().AutoCacheAndMap();
+
+            MapHeadlights();
+        }
+
+        private void MapHeadlights()
+        {
+            CreateMap<FrontConnectedDualCarAutomaticHeadlightsController, FrontConnectedDualCarAutomaticHeadlightsControllerInternal>().AutoCacheAndMap();
+            CreateMap<FrontAndRearConnectedTriCarAutomaticHeadlightsController, FrontAndRearConnectedTriCarAutomaticHeadlightsControllerInternal>().AutoCacheAndMap();
         }
     }
 }

--- a/CCL.Importer/Components/Headlights/FrontAndRearConnectedTriCarAutomaticHeadlightsControllerInternal.cs
+++ b/CCL.Importer/Components/Headlights/FrontAndRearConnectedTriCarAutomaticHeadlightsControllerInternal.cs
@@ -1,0 +1,54 @@
+﻿using DV.Simulation.Cars;
+
+namespace CCL.Importer.Components.Headlights
+{
+    internal class FrontAndRearConnectedTriCarAutomaticHeadlightsControllerInternal : AutomaticHeadlightsController
+    {
+        protected override bool HoseConnected(bool front)
+        {
+            Coupler? coupler;
+
+            if (front)
+            {
+                Coupler frontCoupler = trainCar.frontCoupler;
+                if (frontCoupler == null)
+                {
+                    return false;
+                }
+
+                Coupler coupledTo = frontCoupler.coupledTo;
+                if (coupledTo == null)
+                {
+                    return false;
+                }
+
+                TrainCar train = coupledTo.train;
+                coupler = train != null ? train.frontCoupler : null;
+            }
+            else
+            {
+                Coupler rearCoupler = trainCar.rearCoupler;
+                if (rearCoupler == null)
+                {
+                    return false;
+                }
+
+                Coupler coupledTo = rearCoupler.coupledTo;
+                if (coupledTo == null)
+                {
+                    return false;
+                }
+
+                TrainCar train = coupledTo.train;
+                coupler = train != null ? train.rearCoupler : null;
+            }
+
+            if (coupler != null && coupler.hoseAndCock != null)
+            {
+                return coupler.hoseAndCock.IsHoseConnected;
+            }
+
+            return false;
+        }
+    }
+}

--- a/CCL.Importer/Components/Headlights/FrontConnectedDualCarAutomaticHeadlightsControllerInternal.cs
+++ b/CCL.Importer/Components/Headlights/FrontConnectedDualCarAutomaticHeadlightsControllerInternal.cs
@@ -1,0 +1,41 @@
+﻿using DV.Simulation.Cars;
+
+namespace CCL.Importer.Components.Headlights
+{
+    internal class FrontConnectedDualCarAutomaticHeadlightsControllerInternal : AutomaticHeadlightsController
+    {
+        protected override bool HoseConnected(bool front)
+        {
+            Coupler? coupler;
+
+            if (!front)
+            {
+                coupler = trainCar.rearCoupler;
+            }
+            else
+            {
+                Coupler frontCoupler = trainCar.frontCoupler;
+                if (frontCoupler == null)
+                {
+                    return false;
+                }
+
+                Coupler coupledTo = frontCoupler.coupledTo;
+                if (coupledTo == null)
+                {
+                    return false;
+                }
+
+                TrainCar train = coupledTo.train;
+                coupler = train != null ? train.frontCoupler : null;
+            }
+
+            if (coupler != null && coupler.hoseAndCock != null)
+            {
+                return coupler.hoseAndCock.IsHoseConnected;
+            }
+
+            return false;
+        }
+    }
+}

--- a/CCL.Importer/Processing/GrabberProcessor.cs
+++ b/CCL.Importer/Processing/GrabberProcessor.cs
@@ -132,7 +132,7 @@ namespace CCL.Importer.Processing
             Type t;
             FieldInfo fi;
 
-            foreach (TGrabber grabber in prefab.GetComponentsInChildren<TGrabber>())
+            foreach (TGrabber grabber in prefab.GetComponentsInChildren<TGrabber>(true))
             {
                 t = grabber.ScriptToAffect.GetType();
 
@@ -179,7 +179,7 @@ namespace CCL.Importer.Processing
 
         private static void ProcessMaterialGrabberRenderer(GameObject prefab)
         {
-            foreach (var grabber in prefab.GetComponentsInChildren<MaterialGrabberRenderer>())
+            foreach (var grabber in prefab.GetComponentsInChildren<MaterialGrabberRenderer>(true))
             {
                 foreach (var renderer in grabber.RenderersToAffect)
                 {
@@ -216,7 +216,7 @@ namespace CCL.Importer.Processing
 
         private static void ProcessMeshGrabberFilter(GameObject prefab)
         {
-            foreach (var grabber in prefab.GetComponentsInChildren<MeshGrabberFilter>())
+            foreach (var grabber in prefab.GetComponentsInChildren<MeshGrabberFilter>(true))
             {
                 if (grabber.Filter != null)
                 {
@@ -240,7 +240,7 @@ namespace CCL.Importer.Processing
 
         private static void ProcessSoundGrabberSource(GameObject prefab)
         {
-            foreach (var grabber in prefab.GetComponentsInChildren<SoundGrabberSource>())
+            foreach (var grabber in prefab.GetComponentsInChildren<SoundGrabberSource>(true))
             {
                 if (grabber.Source != null)
                 {

--- a/CCL.Importer/Processing/ProxyScriptProcessor.cs
+++ b/CCL.Importer/Processing/ProxyScriptProcessor.cs
@@ -22,7 +22,7 @@ namespace CCL.Importer.Processing
 
         private void FixEmptyPortIds(GameObject prefab)
         {
-            foreach (var component in prefab.GetComponentsInChildren<Component>())
+            foreach (var component in prefab.GetComponentsInChildren<Component>(true))
             {
                 const BindingFlags ALL_INSTANCE = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 

--- a/CCL.Importer/Proxies/Controllers/MiscControllerReplacer.cs
+++ b/CCL.Importer/Proxies/Controllers/MiscControllerReplacer.cs
@@ -61,6 +61,9 @@ namespace CCL.Importer.Proxies.Controllers
                 .AfterMap(BlowbackParticlePortReaderAfter);
 
             CreateMap<ClapperControllerProxy, ClapperController>().AutoCacheAndMap();
+
+            CreateMap<LightIntensityPortModifierProxy, LightIntensityPortModifier>().AutoCacheAndMap()
+                .ForMember(d => d.cabLightsController, o => o.MapFrom(s => Mapper.GetFromCache(s.cabLightsController)));
         }
 
         private void DeadTractionMotorsControllerAfter(DeadTractionMotorsControllerProxy _, DeadTractionMotorsController controller)

--- a/CCL.Importer/Proxies/Headlights/HeadlightsReplacer.cs
+++ b/CCL.Importer/Proxies/Headlights/HeadlightsReplacer.cs
@@ -29,6 +29,7 @@ namespace CCL.Importer.Proxies.Headlights
                 .AfterMap(VolumetricLightBeamAfter);
 
             CreateMap<AutomaticHeadlightsControllerProxy, AutomaticHeadlightsController>().AutoCacheAndMap();
+            CreateMap<RearConnectedDualCarAutomaticHeadlightsControllerProxy, RearConnectedDualCarAutomaticHeadlightsController>().AutoCacheAndMap();
 
             CreateMap<CarLightsOptimizerProxy, CarLightsOptimizer>().AutoCacheAndMap()
                 .ForMember(d => d.beamController, o => o.MapFrom(s => Mapper.GetFromCache(s.beamController)))

--- a/CCL.Importer/Proxies/Headlights/HeadlightsReplacer.cs
+++ b/CCL.Importer/Proxies/Headlights/HeadlightsReplacer.cs
@@ -1,0 +1,118 @@
+﻿using AutoMapper;
+using CCL.Types.Proxies.Headlights;
+using DV.Simulation.Cars;
+using System.Linq;
+using UnityEngine;
+using VLB;
+
+namespace CCL.Importer.Proxies.Headlights
+{
+    internal class HeadlightsReplacer : Profile
+    {
+        public HeadlightsReplacer()
+        {
+            CreateMap<HeadlightsMainControllerProxy, HeadlightsMainController>().AutoCacheAndMap()
+                .ForMember(d => d.headlightSetupsFront, o => o.Ignore())
+                .ForMember(d => d.headlightSetupsRear, o => o.Ignore())
+                .AfterMap(HeadlightsMainControllerAfter);
+            CreateMap<HeadlightsSubControllerBaseProxy, HeadlightsSubControllerBase>()
+                .ForMember(d => d.headlights, o => o.MapFrom(s => Mapper.GetFromCache(s.headlights)))
+                .IncludeAllDerived();
+            CreateMap<HeadlightsSubControllerStandardProxy, HeadlightsSubControllerStandard>().AutoCacheAndMap();
+
+            CreateMap<HeadlightProxy, Headlight>().AutoCacheAndMap()
+                .ForMember(d => d.beamData, o => o.MapFrom(s => MapBeam(s.beamData)));
+
+            CreateMap<HeadlightBeamControllerProxy, HeadlightBeamController>().AutoCacheAndMap()
+                .ForMember(d => d.headlightsMainController, o => o.MapFrom(s => Mapper.GetFromCache(s.headlightsMainController)));
+            CreateMap<VolumetricLightBeamProxy, VolumetricLightBeam>().AutoCacheAndMap()
+                .AfterMap(VolumetricLightBeamAfter);
+
+            CreateMap<AutomaticHeadlightsControllerProxy, AutomaticHeadlightsController>().AutoCacheAndMap();
+
+            CreateMap<CarLightsOptimizerProxy, CarLightsOptimizer>().AutoCacheAndMap()
+                .ForMember(d => d.beamController, o => o.MapFrom(s => Mapper.GetFromCache(s.beamController)))
+                .ForMember(d => d.cabLightDisableSqrDistance, o => o.MapFrom(s => s.cabLightDisableDistance * s.cabLightDisableDistance))
+                .ForMember(d => d.headLightGlassDisableSqrDistance, o => o.MapFrom(s => s.headLightGlassDisableDistance * s.headLightGlassDisableDistance))
+                .ForMember(d => d.headlightsDisableSqrDistance, o => o.MapFrom(s => s.headlightsDisableDistance * s.headlightsDisableDistance))
+                .ForMember(d => d.glaresDisableSqrDistance, o => o.MapFrom(s => s.glaresDisableDistance * s.glaresDisableDistance))
+                .ForMember(d => d.beamsDisableSqrDistance, o => o.MapFrom(s => s.beamsDisableDistance * s.beamsDisableDistance));
+        }
+
+        private void HeadlightsMainControllerAfter(HeadlightsMainControllerProxy proxy, HeadlightsMainController controller)
+        {
+            controller.headlightSetupsFront = proxy.headlightSetupsFront.Select(setup => new HeadlightsMainController.HeadlightSetup(
+                (HeadlightsMainController.HeadlightSetting)setup.setting,
+                setup.subControllers.Select(subcontroller => (HeadlightsSubControllerBase)Mapper.GetFromCache(subcontroller)).ToArray(),
+                setup.mainOffSetup)).ToArray();
+
+            controller.headlightSetupsRear = proxy.headlightSetupsRear.Select(setup => new HeadlightsMainController.HeadlightSetup(
+                (HeadlightsMainController.HeadlightSetting)setup.setting,
+                setup.subControllers.Select(subcontroller => (HeadlightsSubControllerBase)Mapper.GetFromCache(subcontroller)).ToArray(),
+                setup.mainOffSetup)).ToArray();
+        }
+
+        private VolumetricBeamControllerBase.VolumetricBeamData MapBeam(VolumetricBeamControllerBaseProxy.VolumetricBeamData data)
+        {
+            return new VolumetricBeamControllerBase.VolumetricBeamData()
+            {
+                beam = (VolumetricLightBeam)Mapper.GetFromCache(data.beam),
+                intensityOutsideMax = data.intensityOutsideMax,
+                intensityInsideMax = data.intensityInsideMax
+            };
+        }
+
+        private void VolumetricLightBeamAfter(VolumetricLightBeamProxy proxy, VolumetricLightBeam beam)
+        {
+            beam.gameObject.SetActive(false);
+
+            //beam.colorFromLight
+            //beam.colorMode
+            //beam.color
+            //beam.colorGradient
+            //beam.intensityFromLight
+            //beam.intensityModeAdvanced
+            //beam.intensityInside
+            //beam.intensityOutside
+            beam.blendingMode = BlendingMode.Additive;
+            //beam.spotAngleFromLight
+            //beam.spotAngle
+            beam.coneRadiusStart = 0.1f;
+            beam.shaderAccuracy = ShaderAccuracy.Fast;
+            beam.geomMeshType = MeshType.Shared;
+            beam.geomCustomSides = 18;
+            beam.geomCustomSegments = 5;
+            beam.skewingLocalForwardDirection = new Vector3(0.0f, 0.0f, 1.0f);
+            beam.clippingPlaneTransform = null!;
+            beam.geomCap = true;
+            beam.fallOffEndFromLight = true;
+            beam.attenuationEquation = AttenuationEquation.Quadratic;
+            beam.attenuationCustomBlending = 0.5f;
+            beam.fallOffStart = 0.0f;
+            beam.fallOffEnd = 70.0f;
+            beam.depthBlendDistance = 2.0f;
+            beam.cameraClippingDistance = 0.5f;
+            //beam.glareFrontal
+            beam.glareBehind = 1.0f;
+            beam.fresnelPow = 10.0f;
+            beam.noiseMode = NoiseMode.Disabled;
+            beam.noiseIntensity = 0.5f;
+            beam.noiseScaleUseGlobal = true;
+            beam.noiseScaleLocal = 0.5f;
+            beam.noiseVelocityUseGlobal = true;
+            beam.noiseVelocityLocal = new Vector3(0.07f, 0.18f, 0.05f);
+            beam.dimensions = Dimensions.Dim3D;
+            beam.tiltFactor = Vector2.zero;
+
+            beam.pluginVersion = 1960;
+
+            beam._TrackChangesDuringPlaytime = true;
+            beam._SortingLayerID = 0;
+            beam._SortingOrder = 0;
+            beam._FadeOutBegin = 150;
+            beam._FadeOutEnd = 300;
+
+            beam.ValidateProperties();
+        }
+    }
+}

--- a/CCL.Importer/Proxies/Headlights/HeadlightsReplacer.cs
+++ b/CCL.Importer/Proxies/Headlights/HeadlightsReplacer.cs
@@ -51,6 +51,15 @@ namespace CCL.Importer.Proxies.Headlights
                 (HeadlightsMainController.HeadlightSetting)setup.setting,
                 setup.subControllers.Select(subcontroller => (HeadlightsSubControllerBase)Mapper.GetFromCache(subcontroller)).ToArray(),
                 setup.mainOffSetup)).ToArray();
+
+            foreach (var item in proxy.headlightSetupsFront)
+            {
+                Object.Destroy(item);
+            }
+            foreach (var item in proxy.headlightSetupsRear)
+            {
+                Object.Destroy(item);
+            }
         }
 
         private VolumetricBeamControllerBase.VolumetricBeamData MapBeam(VolumetricBeamControllerBaseProxy.VolumetricBeamData data)

--- a/CCL.Importer/Proxies/PortComponentReplacer.cs
+++ b/CCL.Importer/Proxies/PortComponentReplacer.cs
@@ -24,6 +24,8 @@ namespace CCL.Importer.Proxies
                 .ForMember(d => d.ports, o => o.MapFrom(s => s.Ports.Select(p => p.Port).ToArray()))
                 .ForMember(d => d.startingValues, o => o.MapFrom(s => s.Ports.Select(p => p.StartingValue).ToArray()));
             CreateMap<MultiplePortSumDefinitionProxy, MultiplePortSumDefinition>().AutoCacheAndMap();
+            CreateMap<MultiplePortDecoderEncoderDefinitionProxy, MultiplePortDecoderEncoderDefinition>().AutoCacheAndMap();
+            CreateMap<MultiplePortDecoderEncoderDefinitionProxy.FloatArray, MultiplePortDecoderEncoderDefinition.FloatArray>();
 
             CreateMap<IndependentFusesDefinitionProxy, IndependentFusesDefinition>().AutoCacheAndMap();
 

--- a/CCL.Types/Components/Headlights/FrontAndRearConnectedTriCarAutomaticHeadlightsController.cs
+++ b/CCL.Types/Components/Headlights/FrontAndRearConnectedTriCarAutomaticHeadlightsController.cs
@@ -1,0 +1,6 @@
+﻿using CCL.Types.Proxies.Headlights;
+
+namespace CCL.Types.Components.Headlights
+{
+    public class FrontAndRearConnectedTriCarAutomaticHeadlightsController : AutomaticHeadlightsControllerProxy { }
+}

--- a/CCL.Types/Components/Headlights/FrontConnectedDualCarAutomaticHeadlightsController.cs
+++ b/CCL.Types/Components/Headlights/FrontConnectedDualCarAutomaticHeadlightsController.cs
@@ -1,0 +1,6 @@
+﻿using CCL.Types.Proxies.Headlights;
+
+namespace CCL.Types.Components.Headlights
+{
+    public class FrontConnectedDualCarAutomaticHeadlightsController : AutomaticHeadlightsControllerProxy { }
+}

--- a/CCL.Types/Proxies/Controllers/LightIntensityPortModifierProxy.cs
+++ b/CCL.Types/Proxies/Controllers/LightIntensityPortModifierProxy.cs
@@ -1,0 +1,26 @@
+﻿using CCL.Types.Proxies.Ports;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types.Proxies.Controllers
+{
+    public class LightIntensityPortModifierProxy : MonoBehaviour, IHasPortIdFields
+    {
+        [PortId(DVPortValueType.STATE, false)]
+        public string lightIntensityModifierPortId;
+
+        [Header("Intensity modifier port value mapping")]
+        public float inMapMin;
+        public float inMapMax = 1f;
+        public float outMapMin;
+        public float outMapMax = 1f;
+
+        [Header("optional")]
+        public CabLightsControllerProxy cabLightsController;
+
+        public IEnumerable<PortIdField> ExposedPortIdFields => new[]
+        {
+            new PortIdField(this, nameof(lightIntensityModifierPortId), lightIntensityModifierPortId, DVPortValueType.STATE)
+        };
+    }
+}

--- a/CCL.Types/Proxies/Headlights/AutomaticHeadlightsControllerProxy.cs
+++ b/CCL.Types/Proxies/Headlights/AutomaticHeadlightsControllerProxy.cs
@@ -1,0 +1,6 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Headlights
+{
+    public class AutomaticHeadlightsControllerProxy : MonoBehaviour { }
+}

--- a/CCL.Types/Proxies/Headlights/CarLightsOptimizerProxy.cs
+++ b/CCL.Types/Proxies/Headlights/CarLightsOptimizerProxy.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Headlights
+{
+    public class CarLightsOptimizerProxy : MonoBehaviour
+    {
+        public GameObject[] cabLights;
+        public GameObject[] headLightGlass;
+
+        public float cabLightDisableDistance = 50f;
+        public float headLightGlassDisableDistance = 50f;
+        public float headlightsDisableDistance = 1000f;
+        public float glaresDisableDistance = 2000f;
+        public float beamsDisableDistance = 500f;
+
+        public HeadlightBeamControllerProxy beamController;
+        public float checkPeriod = 0.3f;
+        public Transform positionCheckTransform;
+    }
+}

--- a/CCL.Types/Proxies/Headlights/HeadlightBeamControllerProxy.cs
+++ b/CCL.Types/Proxies/Headlights/HeadlightBeamControllerProxy.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Headlights
+{
+    public class HeadlightBeamControllerProxy : VolumetricBeamControllerBaseProxy
+    {
+        public HeadlightsMainControllerProxy headlightsMainController;
+        public float intensityMultiplier = 1f;
+    }
+}

--- a/CCL.Types/Proxies/Headlights/HeadlightProxy.cs
+++ b/CCL.Types/Proxies/Headlights/HeadlightProxy.cs
@@ -1,0 +1,49 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Headlights
+{
+    public class HeadlightProxy : MonoBehaviour, ICustomSerialized
+    {
+        public VolumetricBeamControllerBaseProxy.VolumetricBeamData beamData;
+        public GameObject glare;
+        public Renderer headlightRenderer;
+        public Material emissionMaterialLit;
+        public Material emissionMaterialUnlit;
+
+        [SerializeField, HideInInspector]
+        private VolumetricLightBeamProxy _beam;
+        [SerializeField, HideInInspector]
+        private float _intensityOutsideMax;
+        [SerializeField, HideInInspector]
+        private float _intensityInsideMax;
+
+        public void OnValidate()
+        {
+            if (glare != null)
+            {
+                glare.gameObject.SetActive(false);
+            }
+
+            if (beamData == null) return;
+
+            _beam = beamData.beam;
+            _intensityOutsideMax = beamData.intensityOutsideMax;
+            _intensityInsideMax = beamData.intensityInsideMax;
+
+            if (_beam != null)
+            {
+                _beam.gameObject.SetActive(false);
+            }
+        }
+
+        public void AfterImport()
+        {
+            beamData = new VolumetricBeamControllerBaseProxy.VolumetricBeamData()
+            {
+                beam = _beam,
+                intensityOutsideMax = _intensityOutsideMax,
+                intensityInsideMax = _intensityInsideMax
+            };
+        }
+    }
+}

--- a/CCL.Types/Proxies/Headlights/HeadlightSetup.cs
+++ b/CCL.Types/Proxies/Headlights/HeadlightSetup.cs
@@ -1,0 +1,32 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Headlights
+{
+    public class HeadlightSetup : MonoBehaviour
+    {
+        public enum HeadlightSetting
+        {
+            Off,
+            HeadlightSetting01,
+            HeadlightSetting02,
+            HeadlightSetting03,
+            HeadlightSetting04,
+            HeadlightSetting05,
+            HeadlightSetting06,
+            HeadlightSetting07,
+            HeadlightSetting08,
+            HeadlightSetting09,
+            HeadlightSetting10,
+            HeadlightSetting11,
+            HeadlightSetting12,
+            HeadlightSetting13,
+            HeadlightSetting14,
+            HeadlightSetting15,
+            HeadlightSetting16
+        }
+
+        public HeadlightSetting setting;
+        public HeadlightsSubControllerBaseProxy[] subControllers;
+        public bool mainOffSetup;
+    }
+}

--- a/CCL.Types/Proxies/Headlights/HeadlightsMainControllerProxy.cs
+++ b/CCL.Types/Proxies/Headlights/HeadlightsMainControllerProxy.cs
@@ -1,0 +1,52 @@
+﻿using CCL.Types.Proxies.Ports;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types.Proxies.Headlights
+{
+    public class HeadlightsMainControllerProxy : MonoBehaviour, IHasPortIdFields, IHasFuseIdFields
+    {
+        [PortId(DVPortValueType.CONTROL, false)]
+        public string headlightControlFrontId;
+        [PortId(DVPortValueType.CONTROL, false)]
+        public string headlightControlRearId;
+        [FuseId]
+        public string powerFuseId;
+
+        public float damagedThresholdPercentage = 0.5f;
+        public HeadlightSetup[] headlightSetupsFront;
+        public HeadlightSetup[] headlightSetupsRear;
+
+        public IEnumerable<PortIdField> ExposedPortIdFields => new[]
+        {
+            new PortIdField(this, nameof(headlightControlFrontId), headlightControlFrontId, DVPortValueType.CONTROL),
+            new PortIdField(this, nameof(headlightControlRearId), headlightControlRearId, DVPortValueType.CONTROL)
+        };
+
+        public IEnumerable<FuseIdField> ExposedFuseIdFields => new[]
+        {
+            new FuseIdField(this, nameof(powerFuseId), powerFuseId)
+        };
+
+        [SerializeField, RenderMethodButtons]
+        [MethodButton(nameof(AutoSetupSetups), "Auto Setup")]
+        private bool _renderButton;
+
+        private void AutoSetupSetups()
+        {
+            var t = transform.Find("FrontSide");
+
+            if (t)
+            {
+                headlightSetupsFront = t.GetComponentsInChildren<HeadlightSetup>();
+            }
+
+            t = transform.Find("RearSide");
+
+            if (t)
+            {
+                headlightSetupsRear = t.GetComponentsInChildren<HeadlightSetup>();
+            }
+        }
+    }
+}

--- a/CCL.Types/Proxies/Headlights/HeadlightsSubControllerBaseProxy.cs
+++ b/CCL.Types/Proxies/Headlights/HeadlightsSubControllerBaseProxy.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Headlights
+{
+    public abstract class HeadlightsSubControllerBaseProxy : MonoBehaviour
+    {
+        public enum HeadlightMUDependency
+        {
+            None,
+            Front,
+            Rear
+        }
+
+        public bool isFront;
+        [SerializeField]
+        protected HeadlightMUDependency multipleUnityDependent;
+        public HeadlightProxy[] headlights;
+        public Light[] lightSources;
+    }
+}

--- a/CCL.Types/Proxies/Headlights/HeadlightsSubControllerBaseProxy.cs
+++ b/CCL.Types/Proxies/Headlights/HeadlightsSubControllerBaseProxy.cs
@@ -12,8 +12,7 @@ namespace CCL.Types.Proxies.Headlights
         }
 
         public bool isFront;
-        [SerializeField]
-        protected HeadlightMUDependency multipleUnityDependent;
+        public HeadlightMUDependency multipleUnityDependent;
         public HeadlightProxy[] headlights;
         public Light[] lightSources;
     }

--- a/CCL.Types/Proxies/Headlights/HeadlightsSubControllerStandardProxy.cs
+++ b/CCL.Types/Proxies/Headlights/HeadlightsSubControllerStandardProxy.cs
@@ -1,0 +1,4 @@
+﻿namespace CCL.Types.Proxies.Headlights
+{
+    public class HeadlightsSubControllerStandardProxy : HeadlightsSubControllerBaseProxy { }
+}

--- a/CCL.Types/Proxies/Headlights/RearConnectedDualCarAutomaticHeadlightsControllerProxy.cs
+++ b/CCL.Types/Proxies/Headlights/RearConnectedDualCarAutomaticHeadlightsControllerProxy.cs
@@ -1,0 +1,4 @@
+﻿namespace CCL.Types.Proxies.Headlights
+{
+    public class RearConnectedDualCarAutomaticHeadlightsControllerProxy : AutomaticHeadlightsControllerProxy { }
+}

--- a/CCL.Types/Proxies/Headlights/VolumetricBeamControllerBaseProxy.cs
+++ b/CCL.Types/Proxies/Headlights/VolumetricBeamControllerBaseProxy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using UnityEngine;
+
+namespace CCL.Types.Proxies.Headlights
+{
+    public class VolumetricBeamControllerBaseProxy : MonoBehaviour
+    {
+        [Serializable]
+        public class VolumetricBeamData
+        {
+            public VolumetricLightBeamProxy beam;
+            public float intensityOutsideMax;
+            public float intensityInsideMax;
+        }
+    }
+}

--- a/CCL.Types/Proxies/Headlights/VolumetricLightBeamProxy.cs
+++ b/CCL.Types/Proxies/Headlights/VolumetricLightBeamProxy.cs
@@ -1,0 +1,191 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Proxies.Headlights
+{
+    public class VolumetricLightBeamProxy : MonoBehaviour
+    {
+        public enum ColorMode
+        {
+            Flat,
+            Gradient
+        }
+
+        private enum LocomotiveDefault
+        {
+            DE2,
+            DE6,
+            DH4,
+            DM3,
+            DM1U,
+            BE2,
+            S060,
+            S282
+        }
+
+        private enum HeadlightType
+        {
+            LowBeam,
+            HighBeam
+        }
+
+        public bool colorFromLight = true;
+        public ColorMode colorMode = ColorMode.Flat;
+        [ColorUsage(false, true)]
+        public Color color = Color.white;
+        public Gradient colorGradient;
+
+        public bool intensityFromLight = true;
+        public bool intensityModeAdvanced = true;
+        public float intensityInside = 0.2f;
+        public float intensityOutside = 0.03f;
+
+        public bool spotAngleFromLight = true;
+        [Range(0.1f, 179.9f)]
+        public float spotAngle = 35f;
+
+        [Range(0f, 1f)]
+        public float glareFrontal = 0.8f;
+
+        [SerializeField]
+        private LocomotiveDefault _locomotiveDefault;
+        [SerializeField]
+        private HeadlightType _headlightType;
+        [SerializeField, RenderMethodButtons]
+        [MethodButton(nameof(ApplyLocoDefaults), "Apply Default Values")]
+        private bool _renderButton;
+
+        private void ApplyLocoDefaults()
+        {
+            colorFromLight = true;
+            intensityFromLight = true;
+            intensityModeAdvanced = true;
+            spotAngleFromLight = true;
+
+            switch (_locomotiveDefault)
+            {
+                case LocomotiveDefault.DE2:
+                    switch (_headlightType)
+                    {
+                        case HeadlightType.LowBeam:
+                            intensityInside = 0.1f;
+                            intensityOutside = 0.01f;
+                            spotAngle = 25.0f;
+                            glareFrontal = 0.3f;
+                            break;
+                        case HeadlightType.HighBeam:
+                            intensityInside = 0.2f;
+                            intensityOutside = 0.03f;
+                            spotAngle = 20.0f;
+                            glareFrontal = 0.8f;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+
+                case LocomotiveDefault.DE6:
+                case LocomotiveDefault.DH4:
+                case LocomotiveDefault.DM3:
+                    intensityInside = 0.42f;
+                    intensityOutside = 0.03f;
+                    spotAngle = 25.0f;
+                    glareFrontal = 0.308f;
+                    break;
+
+                case LocomotiveDefault.DM1U:
+                    intensityInside = 0.42f;
+                    intensityOutside = 0.03f;
+                    spotAngle = 25.0f;
+                    switch (_headlightType)
+                    {
+                        case HeadlightType.LowBeam:
+                            glareFrontal = 0.3f;
+                            break;
+                        case HeadlightType.HighBeam:
+                            glareFrontal = 0.8f;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+
+                case LocomotiveDefault.BE2:
+                    intensityInside = 0.2f;
+                    intensityOutside = 0.03f;
+                    spotAngle = 50.0f;
+                    glareFrontal = 0.8f;
+                    break;
+
+                case LocomotiveDefault.S060:
+                case LocomotiveDefault.S282:
+                    intensityInside = 0.0f;
+                    intensityOutside = 0.0f;
+                    switch (_headlightType)
+                    {
+                        case HeadlightType.LowBeam:
+                            spotAngle = 20.0f;
+                            glareFrontal = 0.8f;
+                            break;
+                        case HeadlightType.HighBeam:
+                            spotAngle = 25.0f;
+                            glareFrontal = 0.3f;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            switch (_headlightType)
+            {
+                case HeadlightType.LowBeam:
+                    transform.localEulerAngles = new Vector3(8.0f, 0.0f, 0.0f);
+                    break;
+                case HeadlightType.HighBeam:
+                    transform.localEulerAngles = new Vector3(1.0f, 0.0f, 0.0f);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void OnValidate()
+        {
+            if (TryGetComponent<Light>(out var light) && light.type == LightType.Spot)
+            {
+                AssignPropertiesFromSpotLight(light);
+            }
+
+            ClampProperties();
+        }
+
+        private void AssignPropertiesFromSpotLight(Light lightSpot)
+        {
+            if (intensityFromLight)
+            {
+                intensityModeAdvanced = false;
+            }
+
+            if (spotAngleFromLight)
+            {
+                spotAngle = lightSpot.spotAngle;
+            }
+
+            if (colorFromLight)
+            {
+                colorMode = ColorMode.Flat;
+                color = lightSpot.color;
+            }
+        }
+
+        private void ClampProperties()
+        {
+            intensityInside = Mathf.Max(intensityInside, 0f);
+            intensityOutside = Mathf.Max(intensityOutside, 0f);
+            spotAngle = Mathf.Clamp(spotAngle, 0.1f, 179.9f);
+            glareFrontal = Mathf.Clamp01(glareFrontal);
+        }
+    }
+}

--- a/CCL.Types/Proxies/Ports/MultiplePortDecoderEncoderDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Ports/MultiplePortDecoderEncoderDefinitionProxy.cs
@@ -1,0 +1,184 @@
+﻿using CCL.Types.Json;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types.Proxies.Ports
+{
+    public class MultiplePortDecoderEncoderDefinitionProxy : SimComponentDefinitionProxy, ICustomSerialized
+    {
+        [Serializable]
+        public class FloatArray
+        {
+            public float this[int i]
+            {
+                get => array[i];
+                set => array[i] = value;
+            }
+
+            public float[] array;
+
+            public FloatArray()
+            {
+                array = Array.Empty<float>();
+            }
+
+            public FloatArray(int length)
+            {
+                array = new float[length];
+            }
+
+            public FloatArray(float[] f)
+            {
+                array = f;
+            }
+        }
+
+        public int combinations;
+        public float defaultOutputValue;
+        public bool useDefaultValueOnMatchNotFound = true;
+        public bool matchClosestOutputValue;
+        public FloatArray[] values = Array.Empty<FloatArray>();
+        public PortDefinition[] inputPorts = Array.Empty<PortDefinition>();
+        public PortDefinition outputPort;
+        public bool saveState;
+
+        [SerializeField, RenderMethodButtons]
+        [MethodButton(nameof(ResizeArrays), "Resize Arrays", "Resizes arrays to have the required length to match the ports")]
+        [MethodButton(nameof(SetupForSingleHeadlightControl), "Setup For Single Headlight Control")]
+        private bool _renderButton;
+
+        [SerializeField, HideInInspector]
+        private string? _inPorts;
+        [SerializeField, HideInInspector]
+        private string? _outPort;
+        [SerializeField, HideInInspector]
+        private int[]? _lenghts;
+        [SerializeField, HideInInspector]
+        private float[]? _values;
+
+        public override IEnumerable<PortDefinition> ExposedPorts
+        {
+            get
+            {
+                foreach (var port in inputPorts) yield return port;
+                yield return outputPort;
+            }
+        }
+
+        private void ResizeArrays()
+        {
+            int length = inputPorts.Length + 1;
+
+            foreach (var item in values)
+            {
+                Array.Resize(ref item.array, length);
+            }
+        }
+
+        private void SetupForSingleHeadlightControl()
+        {
+            values = FromMulti(new[,]
+            {
+                { 0 / 5f, 5 / 5f, 0 / 6f },
+                { 0 / 5f, 4 / 5f, 1 / 6f },
+                { 1 / 5f, 3 / 5f, 2 / 6f },
+                { 2 / 5f, 2 / 5f, 3 / 6f },
+                { 3 / 5f, 1 / 5f, 4 / 6f },
+                { 4 / 5f, 0 / 5f, 5 / 6f },
+                { 5 / 5f, 0 / 5f, 6 / 6f },
+
+                { 2 / 5f, 5 / 5f, 0 / 6f },
+                { 2 / 5f, 4 / 5f, 1 / 6f },
+                { 2 / 5f, 3 / 5f, 2 / 6f },
+                { 2 / 5f, 1 / 5f, 3 / 6f },
+                { 2 / 5f, 0 / 5f, 3 / 6f },
+
+                { 5 / 5f, 2 / 5f, 6 / 6f },
+                { 4 / 5f, 2 / 5f, 5 / 6f },
+                { 3 / 5f, 2 / 5f, 4 / 6f },
+                { 1 / 5f, 2 / 5f, 3 / 6f },
+                { 0 / 5f, 2 / 5f, 3 / 6f },
+
+                { 5 / 5f, 5 / 5f, 3 / 6f },
+                { 0 / 5f, 0 / 5f, 3 / 6f }
+            });
+        }
+
+        private static FloatArray[] FromMulti(float[,] array)
+        {
+            int length = array.GetLength(1);
+            int count = array.GetLength(0);
+
+            FloatArray[] result = new FloatArray[count];
+
+            for (int c = 0; c < count; c++)
+            {
+                var entry = new FloatArray(length);
+
+                for (int i = 0; i < length; i++)
+                {
+                    entry[i] = array[c, i];
+                }
+
+                result[c] = entry;
+            }
+
+            return result;
+        }
+
+        private static FloatArray[] FromJagged(float[][] array)
+        {
+            int count = array.Length;
+
+            FloatArray[] result = new FloatArray[count];
+
+            for (int c = 0; c < count; c++)
+            {
+                result[c] = new FloatArray(array[c]);
+            }
+
+            return result;
+        }
+
+        public void OnValidate()
+        {
+            _inPorts = JSONObject.ToJson(inputPorts);
+            _outPort = JSONObject.ToJson(outputPort);
+
+            List<float> floats = new List<float>();
+            List<int> lenghts = new List<int>();
+
+            foreach (var item in values)
+            {
+                floats.AddRange(item.array);
+                lenghts.Add(item.array.Length);
+            }
+
+            _values = floats.ToArray();
+            _lenghts = lenghts.ToArray();
+        }
+
+        public void AfterImport()
+        {
+            inputPorts = JSONObject.FromJson(_inPorts, () => new PortDefinition[0]);
+            outputPort = JSONObject.FromJson(_outPort, () => new PortDefinition());
+
+            if (_values == null || _lenghts == null) return;
+
+            int index = 0;
+            values = new FloatArray[_lenghts.Length];
+
+            for (int i = 0; i < _lenghts.Length; i++)
+            {
+                int length = _lenghts[i];
+                var array = new FloatArray(length);
+
+                Array.Copy(_values, index, array.array, 0, length);
+
+                index += length;
+                values[i] = array;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added headlight components.
* `HeadlightsMainControllerProxy`
* `HeadlightsSubControllerBaseProxy`
* `HeadlightsSubControllerStandardProxy`
* `HeadlightProxy`
* `HeadlightBeamControllerProxy`
* `VolumetricLightBeamProxy`
* `AutomaticHeadlightsControllerProxy`
* `RearConnectedDualCarAutomaticHeadlightsControllerProxy`
* `CarLightsOptimizerProxy`
* `LightIntensityPortModifierProxy`

Added custom AutomaticHeadlightControllers matching the `RearConnectedDualCarAutomaticHeadlightsController`.
* `FrontConnectedDualCarAutomaticHeadlightsController`, same behaviour but only for a front connection.
* `FrontAndRearConnectedTriCarAutomaticHeadlightsController`, combined version for front and rear connection.

Added `MultiplePortDecoderEncoderDefinitionProxy`.
Fixed grabbers not being detected on inactive objects.
Fixed tender wizard not setting the dummy dynamo port type and value.
Changed bell in DE wizard to use nullable notation.

Closes #228 