### PR TITLE
Cargo Icons and Drip Particles

### DIFF
--- a/CCL.Creator/Wizards/ParticleWizards.cs
+++ b/CCL.Creator/Wizards/ParticleWizards.cs
@@ -19,7 +19,7 @@ namespace CCL.Creator.Wizards
     {
         #region Diesel
 
-        [MenuItem("GameObject/CCL/Particles/Diesel Template", false, 10)]
+        [MenuItem("GameObject/CCL/Particles/Diesel Template", false, 0)]
         public static void CreateDieselParticles(MenuCommand command)
         {
             var target = (GameObject)command.context;
@@ -175,7 +175,7 @@ namespace CCL.Creator.Wizards
             Undo.RegisterCreatedObjectUndo(root, "Created Diesel Particles");
         }
 
-        [MenuItem("GameObject/CCL/Particles/Diesel Template", true, 10)]
+        [MenuItem("GameObject/CCL/Particles/Diesel Template", true, 0)]
         public static bool CreateDieselParticlesValidate()
         {
             return Selection.activeGameObject && !Selection.activeGameObject.transform.parent;
@@ -185,7 +185,7 @@ namespace CCL.Creator.Wizards
 
         #region Steam
 
-        [MenuItem("GameObject/CCL/Particles/Steam Template", false, 10)]
+        [MenuItem("GameObject/CCL/Particles/Steam Template", false, 100)]
         public static void CreateSteamParticles(MenuCommand command)
         {
             var target = (GameObject)command.context;
@@ -738,8 +738,59 @@ namespace CCL.Creator.Wizards
             Undo.RegisterCreatedObjectUndo(root, "Created Steam Particles");
         }
 
-        [MenuItem("GameObject/CCL/Particles/Steam Template", true, 10)]
+        [MenuItem("GameObject/CCL/Particles/Steam Template", true, 100)]
         public static bool CreateSteamParticlesValidate()
+        {
+            return Selection.activeGameObject && !Selection.activeGameObject.transform.parent;
+        }
+
+        [MenuItem("GameObject/CCL/Particles/Boiler Water Drip", true, 101)]
+        public static void CreateBoilerWaterDripParticles(MenuCommand command)
+        {
+            var target = (GameObject)command.context;
+
+            var root = new GameObject(CarPartNames.Particles.ROOT);
+            root.transform.parent = target.transform;
+
+            var comp = root.AddComponent<ParticlesPortReadersControllerProxy>();
+
+            var drip = new GameObject("SteamIndicatorWaterDripping").AddComponent<CopyVanillaParticleSystem>();
+            drip.SystemToCopy = VanillaParticleSystem.SteamerIndicatorWaterDrip;
+            drip.transform.parent = comp.transform;
+
+            comp.particlePortReaders = new List<ParticlePortReader>
+            {
+                new ParticlePortReader
+                {
+                    particlesParent = drip.gameObject,
+                    particleUpdaters = new List<ParticlePortReader.PortParticleUpdateDefinition>
+                    {
+                        new ParticlePortReader.PortParticleUpdateDefinition
+                        {
+                            portId = string.Empty,
+                            inputModifier = new ValueModifier(),
+                            propertiesToUpdate = new List<ParticlePortReader.PropertyChangeDefinition>
+                            {
+                                new ParticlePortReader.PropertyChangeDefinition
+                                {
+                                    propertyType = ParticlePortReader.ParticleProperty.ON_OFF,
+                                    propertyChangeCurve = new AnimationCurve(
+                                        new Keyframe(0, 0, 0, 0, 0, 0),
+                                        new Keyframe(0.97f, 0, 0, 0, 1 / 3f, 1 / 3f),
+                                        new Keyframe(0.98f, 0, -0.015855882f, -0.015855882f, 1, 1 / 3f),
+                                        new Keyframe(1, 1, 0, 0, 1 / 3f, 1 / 3f))
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            Undo.RegisterCreatedObjectUndo(root, "Created Boiler Drip Particles");
+        }
+
+        [MenuItem("GameObject/CCL/Particles/Boiler Water Drip", true, 101)]
+        public static bool CreateBoilerWaterDripParticlesValidate()
         {
             return Selection.activeGameObject && !Selection.activeGameObject.transform.parent;
         }

--- a/CCL.Importer/CargoInjector.cs
+++ b/CCL.Importer/CargoInjector.cs
@@ -45,7 +45,7 @@ namespace CCL.Importer
             // It should never be null if we get here, but it doesn't hurt to check.
             if (ccl.CargoSetup == null || !ccl.CargoSetup.Entries.TryFind(x => x.CargoId == cargo.id, out var entry)) return null!;
 
-            return entry.LoadedIcon;
+            return entry.OverrideLoadedIcon ? entry.LoadedIcon : cargo.icon;
         }
     }
 }

--- a/CCL.Importer/CargoInjector.cs
+++ b/CCL.Importer/CargoInjector.cs
@@ -3,6 +3,7 @@ using CCL.Importer.Types;
 using DV;
 using DV.ThingTypes;
 using HarmonyLib;
+using UnityEngine;
 
 namespace CCL.Importer
 {
@@ -35,6 +36,16 @@ namespace CCL.Importer
                 var loadableInfo = new CargoType_v2.LoadableInfo(carType, entry.Models);
                 matchCargo.loadableCarTypes = matchCargo.loadableCarTypes.AddToArray(loadableInfo);
             }
+        }
+
+        public static Sprite GetCargoIcon(CargoType_v2 cargo, TrainCarType_v2 car)
+        {
+            if (car is not CCL_CarType ccl) return cargo.icon;
+
+            // It should never be null if we get here, but it doesn't hurt to check.
+            if (ccl.CargoSetup == null || !ccl.CargoSetup.Entries.TryFind(x => x.CargoId == cargo.id, out var entry)) return null!;
+
+            return entry.LoadedIcon;
         }
     }
 }

--- a/CCL.Importer/Components/WheelRotationViaAnimation.cs
+++ b/CCL.Importer/Components/WheelRotationViaAnimation.cs
@@ -1,7 +1,7 @@
 ﻿using DV.Wheels;
 using UnityEngine;
 
-namespace CCL.Importer.Types
+namespace CCL.Importer.Components
 {
     public class WheelRotationViaAnimation : WheelRotationBase
     {

--- a/CCL.Importer/Patches/TaskTemplatePaperPatches.cs
+++ b/CCL.Importer/Patches/TaskTemplatePaperPatches.cs
@@ -1,0 +1,32 @@
+﻿using DV.RenderTextureSystem.BookletRender;
+using DV.ThingTypes;
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace CCL.Importer.Patches
+{
+    [HarmonyPatch(typeof(TaskTemplatePaper))]
+    internal class TaskTemplatePaperPatches
+    {
+        private static FieldInfo? s_iconField;
+        private static FieldInfo IconField => Extensions.GetCached(ref s_iconField, () =>
+            typeof(CargoType_v2).GetField(nameof(CargoType_v2.icon)));
+
+        //[HarmonyTranspiler, HarmonyPatch(nameof(TaskTemplatePaper.FillInData))]
+        //private static IEnumerable<CodeInstruction> FillInDataTranspiler(IEnumerable<CodeInstruction> instructions)
+        //{
+        //    foreach (var instruction in instructions)
+        //    {
+        //        if (instruction.LoadsField(IconField))
+        //        {
+        //            yield return CodeInstruction.LoadField();
+        //        }
+        //        else
+        //        {
+        //            yield return instruction;
+        //        }
+        //    }
+        //}
+    }
+}

--- a/CCL.Importer/Processing/ObjectInstancerProcessor.cs
+++ b/CCL.Importer/Processing/ObjectInstancerProcessor.cs
@@ -134,6 +134,8 @@ namespace CCL.Importer.Processing
                 VanillaParticleSystem.SteamerExhaustLargeWave           => TrainCarType.LocoSteamHeavy.ToV2().prefab.transform.Find(
                     "LocoS282A_Particles/Blowdown/SteamExhaust Large/GasWave").GetComponent<ParticleSystem>(),
 
+                VanillaParticleSystem.SteamerIndicatorWaterDrip => TrainCarType.LocoSteamHeavy.ToV2().interiorPrefab.transform.Find(
+                    "[particles]/SteamIndicatorWaterDripping").GetComponent<ParticleSystem>(),
 
                 VanillaParticleSystem.SteamerSteamLeaks                 => TrainCarType.LocoSteamHeavy.ToV2().prefab.transform.Find(
                     "LocoS282A_Particles/RandomLeaks/SteamLeaks/SteamLeaks").GetComponent<ParticleSystem>(),

--- a/CCL.Importer/Proxies/Wheels/WheelProxyReplacer.cs
+++ b/CCL.Importer/Proxies/Wheels/WheelProxyReplacer.cs
@@ -1,5 +1,5 @@
 ﻿using AutoMapper;
-using CCL.Importer.Types;
+using CCL.Importer.Components;
 using CCL.Types.Proxies.Wheels;
 using DV;
 using DV.Wheels;

--- a/CCL.Types/CargoSetup.cs
+++ b/CCL.Types/CargoSetup.cs
@@ -12,11 +12,13 @@ namespace CCL.Types
         public List<CargoEntry> Entries = new List<CargoEntry>();
 
         [SerializeField, HideInInspector]
+        private string? _json;
+        [SerializeField, HideInInspector]
+        private Sprite[]? _sprite;
+        [SerializeField, HideInInspector]
         private GameObject[]? _models;
         [SerializeField, HideInInspector]
         private int[]? _counts;
-        [SerializeField, HideInInspector]
-        private string? _json;
 
         [RenderMethodButtons, SerializeField]
         [MethodButton(nameof(SortEntries), "Sort Entries")]
@@ -27,24 +29,35 @@ namespace CCL.Types
 
         private void OnValidate()
         {
+            _json = JSONObject.ToJson(Entries);
+
+            var sprite = new List<Sprite>();
             var models = new List<GameObject>();
             var counts = new List<int>();
 
             foreach (var item in Entries)
             {
+                sprite.Add(item.LoadedIcon);
                 models.AddRange(item.Models);
                 counts.Add(item.Models.Length);
             }
 
+            _sprite = sprite.ToArray();
             _models = models.ToArray();
             _counts = counts.ToArray();
-
-            _json = JSONObject.ToJson(Entries);
         }
 
         public void AfterAssetLoad(AssetBundle bundle)
         {
             Entries = JSONObject.FromJson(_json, () => new List<CargoEntry>());
+
+            if (_sprite != null)
+            {
+                for (int i = 0; i < Entries.Count; i++)
+                {
+                    Entries[i].LoadedIcon = _sprite[i];
+                }
+            }
 
             if (_counts == null || _models == null) return;
 
@@ -78,6 +91,8 @@ namespace CCL.Types
         [CargoField]
         public string CargoId = string.Empty;
         public float AmountPerCar = 1f;
+        [JsonIgnore]
+        public Sprite LoadedIcon = null!;
         [JsonIgnore]
         public GameObject[] Models = new GameObject[0];
     }

--- a/CCL.Types/CargoSetup.cs
+++ b/CCL.Types/CargoSetup.cs
@@ -91,6 +91,7 @@ namespace CCL.Types
         [CargoField]
         public string CargoId = string.Empty;
         public float AmountPerCar = 1f;
+        public bool OverrideLoadedIcon = true;
         [JsonIgnore]
         public Sprite LoadedIcon = null!;
         [JsonIgnore]

--- a/CCL.Types/Components/CopyVanillaParticleSystem.cs
+++ b/CCL.Types/Components/CopyVanillaParticleSystem.cs
@@ -32,6 +32,7 @@ namespace CCL.Types.Components
         SteamerExhaustWave,
         SteamerExhaustLargeWispy,
         SteamerExhaustLargeWave,
+        SteamerIndicatorWaterDrip = 180,
         SteamerSteamLeaks = 190,
 
         FireboxFire = 200,

--- a/CCL.Types/Proxies/VFX/ParticlesPortReadersControllerProxy.cs
+++ b/CCL.Types/Proxies/VFX/ParticlesPortReadersControllerProxy.cs
@@ -18,6 +18,7 @@ namespace CCL.Types.Proxies.VFX
 
         public List<ParticlePortReader> particlePortReaders = new List<ParticlePortReader>();
         public List<ParticleColorPortReader> particleColorPortReaders = new List<ParticleColorPortReader>();
+        public bool selfInitialization = false;
 
         [SerializeField, HideInInspector]
         private GameObject[] _goPort = new GameObject[0];
@@ -120,47 +121,47 @@ namespace CCL.Types.Proxies.VFX
             public class PropertyChangeDefinition
             {
                 public ParticleProperty propertyType;
-                public AnimationCurve propertyChangeCurve;
+                public AnimationCurve propertyChangeCurve = new AnimationCurve();
             }
 
             [Serializable]
             public class PortParticleUpdateDefinition
             {
                 [PortId(null, null, false)]
-                public string portId;
-                public ValueModifier inputModifier;
-                public List<PropertyChangeDefinition> propertiesToUpdate;
+                public string portId = string.Empty;
+                public ValueModifier inputModifier = new ValueModifier();
+                public List<PropertyChangeDefinition> propertiesToUpdate = new List<PropertyChangeDefinition>();
             }
         }
 
         [Serializable]
         public class ParticleColorPortReader
         {
-            public GameObject particlesParent;
+            public GameObject particlesParent = null!;
             [PortId(null, null, false)]
-            public string portId;
-            public ValueModifier inputModifier;
+            public string portId = string.Empty;
+            public ValueModifier inputModifier = new ValueModifier();
             public ColorPropertyChange changeType;
             public Color startColorMin;
             public Color startColorMax;
-            public AnimationCurve colorLerpCurve;
+            public AnimationCurve colorLerpCurve = new AnimationCurve();
         }
 
         [Serializable, NotProxied]
         public class FakeParticleColorPortReader
         {
-            public string portId;
-            public ValueModifier inputModifier;
+            public string portId = string.Empty;
+            public ValueModifier inputModifier = new ValueModifier();
             public ColorPropertyChange changeType;
-            public float startColorMinR;
-            public float startColorMinG;
-            public float startColorMinB;
-            public float startColorMinA;
-            public float startColorMaxR;
-            public float startColorMaxG;
-            public float startColorMaxB;
-            public float startColorMaxA;
-            public AnimationCurve colorLerpCurve;
+            public float startColorMinR = 0;
+            public float startColorMinG = 0;
+            public float startColorMinB = 0;
+            public float startColorMinA = 0;
+            public float startColorMaxR = 0;
+            public float startColorMaxG = 0;
+            public float startColorMaxB = 0;
+            public float startColorMaxA = 0;
+            public AnimationCurve colorLerpCurve = new AnimationCurve();
 
             // Default constructor for deserialization.
             public FakeParticleColorPortReader() { }
@@ -199,10 +200,10 @@ namespace CCL.Types.Proxies.VFX
         [Serializable]
         public class ValueModifier
         {
-            public float valueMultiplier = 1f;
-            public float valueOffset;
-            public bool absoluteInputValue;
-            public bool absoluteResultValue;
+            public float valueMultiplier = 1;
+            public float valueOffset = 0;
+            public bool absoluteInputValue = false;
+            public bool absoluteResultValue = false;
         }
     }
 }


### PR DESCRIPTION
Added sprites to cargo to use custom icons instead of the default one.
* Currently not used, but this way it can already be set for when it is used.

Added boiler/sightglass water drip particles.
* Separate from the normal steamer particles, this goes in the interior.