### PR TITLE
Menu Enhancements

### DIFF
--- a/CCL.Creator/MenuOrdering.cs
+++ b/CCL.Creator/MenuOrdering.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CCL.Creator
+{
+    internal static class MenuOrdering
+    {
+        public static class Particles
+        {
+            public const int Diesel = 0;
+            public const int Steam = 100;
+        }
+    }
+}

--- a/CCL.Creator/MenuOrdering.cs
+++ b/CCL.Creator/MenuOrdering.cs
@@ -1,13 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CCL.Creator
+﻿namespace CCL.Creator
 {
     internal static class MenuOrdering
     {
+        public const int Simulation = 10;
+
+        public static class Cab
+        {
+            public const int Control = 100;
+            public const int Indicator = 101;
+            public const int Lamp = 102;
+            public const int Label = 103;
+        }
+
+        public static class Body
+        {
+            public const int Headlights = 200;
+            public const int Cab = 201;
+            public const int LicenseBlocker = 202;
+        }
+
         public static class Particles
         {
             public const int Diesel = 0;

--- a/CCL.Creator/Wizards/ControlWizard.cs
+++ b/CCL.Creator/Wizards/ControlWizard.cs
@@ -13,7 +13,7 @@ namespace CCL.Creator.Wizards
     {
         private static ControlWizard? _instance;
 
-        [MenuItem("GameObject/CCL/Add Control", false, 10)]
+        [MenuItem("GameObject/CCL/Add Control", false, MenuOrdering.Cab.Control)]
         public static void ShowWindow(MenuCommand command)
         {
             _instance = GetWindow<ControlWizard>();
@@ -22,7 +22,7 @@ namespace CCL.Creator.Wizards
             _instance.Show();
         }
 
-        [MenuItem("GameObject/CCL/Add Control", true, 10)]
+        [MenuItem("GameObject/CCL/Add Control", true, MenuOrdering.Cab.Control)]
         public static bool OnContextMenuValidate()
         {
             return Selection.activeGameObject;

--- a/CCL.Creator/Wizards/HeadlightWizard.cs
+++ b/CCL.Creator/Wizards/HeadlightWizard.cs
@@ -29,7 +29,7 @@ namespace CCL.Creator.Wizards
         private Settings _settingsR = null!;
         private Settings _settingsF = null!;
 
-        [MenuItem("GameObject/CCL/Create Headlights", false, 10)]
+        [MenuItem("GameObject/CCL/Add Headlights", false, MenuOrdering.Body.Headlights)]
         public static void ShowWindow(MenuCommand command)
         {
             s_instance = GetWindow<HeadlightWizard>();
@@ -41,7 +41,7 @@ namespace CCL.Creator.Wizards
             s_instance.Show();
         }
 
-        [MenuItem("GameObject/CCL/Create Headlights", true, 10)]
+        [MenuItem("GameObject/CCL/Add Headlights", true, MenuOrdering.Body.Headlights)]
         public static bool OnContextMenuValidate()
         {
             return Selection.activeGameObject;

--- a/CCL.Creator/Wizards/IndicatorWizard.cs
+++ b/CCL.Creator/Wizards/IndicatorWizard.cs
@@ -1,13 +1,8 @@
 ﻿using CCL.Creator.Inspector;
 using CCL.Creator.Utility;
-using CCL.Types.Proxies.Controls;
 using CCL.Types.Proxies.Indicators;
 using CCL.Types.Proxies.Ports;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 
@@ -17,7 +12,7 @@ namespace CCL.Creator.Wizards
     {
         private static IndicatorWizard? _instance;
 
-        [MenuItem("GameObject/CCL/Add Indicator", false, 10)]
+        [MenuItem("GameObject/CCL/Add Indicator", false, MenuOrdering.Cab.Indicator)]
         public static void ShowWindow(MenuCommand command)
         {
             _instance = GetWindow<IndicatorWizard>();
@@ -26,7 +21,7 @@ namespace CCL.Creator.Wizards
             _instance.Show();
         }
 
-        [MenuItem("GameObject/CCL/Add Indicator", true, 10)]
+        [MenuItem("GameObject/CCL/Add Indicator", true, MenuOrdering.Cab.Indicator)]
         public static bool OnContextMenuValidate()
         {
             return Selection.activeGameObject;

--- a/CCL.Creator/Wizards/LabelWizard.cs
+++ b/CCL.Creator/Wizards/LabelWizard.cs
@@ -1,11 +1,6 @@
 ﻿using CCL.Creator.Inspector;
 using CCL.Creator.Utility;
 using CCL.Types.Proxies.Indicators;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TMPro;
 using UnityEditor;
 using UnityEngine;
@@ -16,7 +11,7 @@ namespace CCL.Creator.Wizards
     {
         private static LabelWizard? _instance;
 
-        [MenuItem("GameObject/CCL/Add Label", false, 10)]
+        [MenuItem("GameObject/CCL/Add Label", false, MenuOrdering.Cab.Label)]
         public static void ShowWindow(MenuCommand command)
         {
             _instance = GetWindow<LabelWizard>();
@@ -25,7 +20,7 @@ namespace CCL.Creator.Wizards
             _instance.Show();
         }
 
-        [MenuItem("GameObject/CCL/Add Label", true, 10)]
+        [MenuItem("GameObject/CCL/Add Label", true, MenuOrdering.Cab.Label)]
         public static bool OnContextMenuValidate()
         {
             return Selection.activeGameObject;

--- a/CCL.Creator/Wizards/LampWizard.cs
+++ b/CCL.Creator/Wizards/LampWizard.cs
@@ -1,13 +1,8 @@
 ﻿using CCL.Creator.Inspector;
 using CCL.Creator.Utility;
-using CCL.Types.Proxies.Controls;
 using CCL.Types.Proxies.Indicators;
 using CCL.Types.Proxies.Ports;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 
@@ -17,7 +12,7 @@ namespace CCL.Creator.Wizards
     {
         private static LampWizard? _instance;
 
-        [MenuItem("GameObject/CCL/Add Lamp", false, 10)]
+        [MenuItem("GameObject/CCL/Add Lamp", false, MenuOrdering.Cab.Lamp)]
         public static void ShowWindow(MenuCommand command)
         {
             _instance = GetWindow<LampWizard>();
@@ -26,7 +21,7 @@ namespace CCL.Creator.Wizards
             _instance.Show();
         }
 
-        [MenuItem("GameObject/CCL/Add Lamp", true, 10)]
+        [MenuItem("GameObject/CCL/Add Lamp", true, MenuOrdering.Cab.Lamp)]
         public static bool OnContextMenuValidate()
         {
             return Selection.activeGameObject;

--- a/CCL.Creator/Wizards/ParticleWizards.cs
+++ b/CCL.Creator/Wizards/ParticleWizards.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+
 using static CCL.Types.Proxies.VFX.ParticlesPortReadersControllerProxy;
 
 namespace CCL.Creator.Wizards
@@ -19,7 +20,7 @@ namespace CCL.Creator.Wizards
     {
         #region Diesel
 
-        [MenuItem("GameObject/CCL/Particles/Diesel Template", false, 0)]
+        [MenuItem("GameObject/CCL/Particles/Diesel Template", false, MenuOrdering.Particles.Diesel)]
         public static void CreateDieselParticles(MenuCommand command)
         {
             var target = (GameObject)command.context;
@@ -175,7 +176,7 @@ namespace CCL.Creator.Wizards
             Undo.RegisterCreatedObjectUndo(root, "Created Diesel Particles");
         }
 
-        [MenuItem("GameObject/CCL/Particles/Diesel Template", true, 0)]
+        [MenuItem("GameObject/CCL/Particles/Diesel Template", true, MenuOrdering.Particles.Diesel)]
         public static bool CreateDieselParticlesValidate()
         {
             return Selection.activeGameObject && !Selection.activeGameObject.transform.parent;
@@ -185,7 +186,7 @@ namespace CCL.Creator.Wizards
 
         #region Steam
 
-        [MenuItem("GameObject/CCL/Particles/Steam Template", false, 100)]
+        [MenuItem("GameObject/CCL/Particles/Steam Template", false, MenuOrdering.Particles.Steam)]
         public static void CreateSteamParticles(MenuCommand command)
         {
             var target = (GameObject)command.context;
@@ -738,13 +739,13 @@ namespace CCL.Creator.Wizards
             Undo.RegisterCreatedObjectUndo(root, "Created Steam Particles");
         }
 
-        [MenuItem("GameObject/CCL/Particles/Steam Template", true, 100)]
+        [MenuItem("GameObject/CCL/Particles/Steam Template", true, MenuOrdering.Particles.Steam)]
         public static bool CreateSteamParticlesValidate()
         {
             return Selection.activeGameObject && !Selection.activeGameObject.transform.parent;
         }
 
-        [MenuItem("GameObject/CCL/Particles/Boiler Water Drip", true, 101)]
+        [MenuItem("GameObject/CCL/Particles/Boiler Water Drip", false, MenuOrdering.Particles.Steam + 1)]
         public static void CreateBoilerWaterDripParticles(MenuCommand command)
         {
             var target = (GameObject)command.context;
@@ -789,7 +790,7 @@ namespace CCL.Creator.Wizards
             Undo.RegisterCreatedObjectUndo(root, "Created Boiler Drip Particles");
         }
 
-        [MenuItem("GameObject/CCL/Particles/Boiler Water Drip", true, 101)]
+        [MenuItem("GameObject/CCL/Particles/Boiler Water Drip", true, MenuOrdering.Particles.Steam + 1)]
         public static bool CreateBoilerWaterDripParticlesValidate()
         {
             return Selection.activeGameObject && !Selection.activeGameObject.transform.parent;

--- a/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
+++ b/CCL.Creator/Wizards/SimSetup/SimCreatorWindow.cs
@@ -28,7 +28,7 @@ namespace CCL.Creator.Wizards.SimSetup
 
         private static SimCreatorWindow? _instance;
 
-        [MenuItem("GameObject/CCL/Create Loco Simulation", false, 10)]
+        [MenuItem("GameObject/CCL/Create Loco Simulation", false, MenuOrdering.Simulation)]
         public static void OnContextMenu(MenuCommand command)
         {
             var selection = (GameObject)command.context;
@@ -39,7 +39,7 @@ namespace CCL.Creator.Wizards.SimSetup
             _instance.Show();
         }
 
-        [MenuItem("GameObject/CCL/Create Loco Simulation", true, 10)]
+        [MenuItem("GameObject/CCL/Create Loco Simulation", true, MenuOrdering.Simulation)]
         public static bool OnContextMenuValidate()
         {
             return Selection.activeGameObject;

--- a/CCL.Creator/Wizards/WizardlessWizards.cs
+++ b/CCL.Creator/Wizards/WizardlessWizards.cs
@@ -7,7 +7,7 @@ namespace CCL.Creator.Wizards
 {
     internal class WizardlessWizards
     {
-        [MenuItem("GameObject/CCL/Add Cab", false, 10)]
+        [MenuItem("GameObject/CCL/Add Cab", false, MenuOrdering.Body.Cab)]
         public static void CreateCab(MenuCommand command)
         {
             var target = (GameObject)command.context;
@@ -39,13 +39,13 @@ namespace CCL.Creator.Wizards
             Undo.RegisterCreatedObjectUndo(cab, "Created Cab");
         }
 
-        [MenuItem("GameObject/CCL/Add Cab", true, 10)]
+        [MenuItem("GameObject/CCL/Add Cab", true, MenuOrdering.Body.Cab)]
         public static bool CreateCabValidate()
         {
             return Selection.activeGameObject;
         }
 
-        [MenuItem("GameObject/CCL/Add License Blocker", false, 10)]
+        [MenuItem("GameObject/CCL/Add License Blocker", false, MenuOrdering.Body.LicenseBlocker)]
         public static void CreateLicenseBlocker(MenuCommand command)
         {
             var target = (GameObject)command.context;
@@ -69,7 +69,7 @@ namespace CCL.Creator.Wizards
             Undo.RegisterCreatedObjectUndo(blocker, "Created License Blocker");
         }
 
-        [MenuItem("GameObject/CCL/Add License Blocker", true, 10)]
+        [MenuItem("GameObject/CCL/Add License Blocker", true, MenuOrdering.Body.LicenseBlocker)]
         public static bool CreateLicenseBlockerValidate()
         {
             return Selection.activeGameObject;

--- a/CCL.Types/CargoSetup.cs
+++ b/CCL.Types/CargoSetup.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace CCL.Types
 {
-    [CreateAssetMenu(menuName = "CCL/Cargo Setup")]
+    [CreateAssetMenu(menuName = "CCL/Cargo Setup", order = MenuOrdering.CargoSetup)]
     public class CargoSetup : ScriptableObject, IAssetLoadCallback
     {
         public List<CargoEntry> Entries = new List<CargoEntry>();

--- a/CCL.Types/Catalog/CatalogPage.cs
+++ b/CCL.Types/Catalog/CatalogPage.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace CCL.Types.Catalog
 {
-    [CreateAssetMenu(menuName = "CCL/Vehicle Catalog Page")]
+    [CreateAssetMenu(menuName = "CCL/Vehicle Catalog Page", order = MenuOrdering.Catalog)]
     public class CatalogPage : ScriptableObject, ICustomSerialized
     {
         [Header("Header")]

--- a/CCL.Types/CustomCarType.cs
+++ b/CCL.Types/CustomCarType.cs
@@ -8,7 +8,7 @@ using CCL.Types.Catalog;
 
 namespace CCL.Types
 {
-    [CreateAssetMenu(menuName = "CCL/Custom Car Type")]
+    [CreateAssetMenu(menuName = "CCL/Custom Car Type", order = MenuOrdering.CarType)]
     public class CustomCarType : ScriptableObject, IAssetLoadCallback
     {
         public enum UnusedCarDeletePreventionMode

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -5,7 +5,7 @@ using CCL.Types.Json;
 
 namespace CCL.Types
 {
-    [CreateAssetMenu(menuName = "CCL/Car Variant")]
+    [CreateAssetMenu(menuName = "CCL/Car Variant", order = MenuOrdering.CarLivery)]
     public class CustomCarVariant : ScriptableObject
     {
         [Header("Basic Properties")]

--- a/CCL.Types/Extensions.cs
+++ b/CCL.Types/Extensions.cs
@@ -68,5 +68,12 @@ namespace CCL.Types
         {
             return new Vector2(vector.x, vector.z);
         }
+
+        public static void Reset(this Transform transform)
+        {
+            transform.localPosition = Vector3.zero;
+            transform.localRotation = Quaternion.identity;
+            transform.localScale = Vector3.one;
+        }
     }
 }

--- a/CCL.Types/ExtraTranslations.cs
+++ b/CCL.Types/ExtraTranslations.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace CCL.Types
 {
-    [CreateAssetMenu(menuName = "CCL/Extra Translations")]
+    [CreateAssetMenu(menuName = "CCL/Extra Translations", order = MenuOrdering.ExtraTranslations)]
     public class ExtraTranslations : ScriptableObject, ICustomSerialized
     {
         public string? CSV_Url;

--- a/CCL.Types/HUD/VanillaHUDLayout.cs
+++ b/CCL.Types/HUD/VanillaHUDLayout.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace CCL.Types.HUD
 {
-    [CreateAssetMenu(menuName = "CCL/HUD Layout")]
+    [CreateAssetMenu(menuName = "CCL/HUD Layout", order = MenuOrdering.HUDLayout)]
     public class VanillaHUDLayout : ScriptableObject, ICustomSerialized
     {
         public enum BaseHUD

--- a/CCL.Types/MenuOrdering.cs
+++ b/CCL.Types/MenuOrdering.cs
@@ -1,0 +1,15 @@
+﻿namespace CCL.Types
+{
+    internal static class MenuOrdering
+    {
+        public const int CarPack = 0;
+        public const int CarType = 1;
+        public const int CarLivery = 2;
+
+        public const int HUDLayout = 100;
+        public const int PaintSubstitutions = 101;
+        public const int Catalog = 102;
+
+        public const int ExtraTranslations = 200;
+    }
+}

--- a/CCL.Types/MenuOrdering.cs
+++ b/CCL.Types/MenuOrdering.cs
@@ -6,9 +6,10 @@
         public const int CarType = 1;
         public const int CarLivery = 2;
 
-        public const int HUDLayout = 100;
-        public const int PaintSubstitutions = 101;
-        public const int Catalog = 102;
+        public const int CargoSetup = 100;
+        public const int HUDLayout = 101;
+        public const int PaintSub = 102;
+        public const int Catalog = 103;
 
         public const int ExtraTranslations = 200;
     }

--- a/CCL.Types/PaintSubstitutions.cs
+++ b/CCL.Types/PaintSubstitutions.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace CCL.Types
 {
-    [CreateAssetMenu(menuName = "CCL/Paint Substitutions", order = MenuOrdering.PaintSubstitutions)]
+    [CreateAssetMenu(menuName = "CCL/Paint Substitutions", order = MenuOrdering.PaintSub)]
     public class PaintSubstitutions : ScriptableObject, ICustomSerialized
     {
         [Serializable]

--- a/CCL.Types/PaintSubstitutions.cs
+++ b/CCL.Types/PaintSubstitutions.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace CCL.Types
 {
-    [CreateAssetMenu(menuName = "CCL/Paint Substitutions")]
+    [CreateAssetMenu(menuName = "CCL/Paint Substitutions", order = MenuOrdering.PaintSubstitutions)]
     public class PaintSubstitutions : ScriptableObject, ICustomSerialized
     {
         [Serializable]


### PR DESCRIPTION
Improved Control Wizard by adding automatic reparenting.
* Can automatically reparent a transform to quickly change from model structure to control structure (`interior/leverModel` to `interior/holder/leverControl/leverModel`).

Improved menu ordering of CCL GameObject and Asset menus.