### PR TITLE
Combined Throttle/Dynamic Brake, IndicatorTMP

### DIFF
--- a/CCL.Creator/Inspector/SimComponentDefinitionProxyEditor.cs
+++ b/CCL.Creator/Inspector/SimComponentDefinitionProxyEditor.cs
@@ -4,7 +4,7 @@ using UnityEditor;
 
 namespace CCL.Creator.Inspector
 {
-    [CustomEditor(typeof(SimComponentDefinitionProxy), true)]
+    [CustomEditor(typeof(SimComponentDefinitionProxy), true), CanEditMultipleObjects]
     internal class SimComponentDefinitionProxyEditor : Editor
     {
         public override void OnInspectorGUI()

--- a/CCL.Creator/Wizards/LampWizard.cs
+++ b/CCL.Creator/Wizards/LampWizard.cs
@@ -35,7 +35,8 @@ namespace CCL.Creator.Wizards
                 Port,
                 Fuse,
                 BrakeIssues,
-                Wheelslip
+                Wheelslip,
+                TemperatureMU
             }
 
             public GameObject TargetObject = null!;
@@ -153,6 +154,11 @@ namespace CCL.Creator.Wizards
                 case Settings.ReaderType.Wheelslip:
                     var wheelSlipReader = holder.AddComponent<LampWheelSlipSlideReaderProxy>();
                     wheelSlipReader.fuseId = settings.FuseId;
+                    break;
+
+                case Settings.ReaderType.TemperatureMU:
+                    var temperatureReader = holder.AddComponent<LampControllerTemperatureMUProxy>();
+                    temperatureReader.fuseId = settings.FuseId;
                     break;
             }
 

--- a/CCL.Importer/Components/ControlNameTMPDisplayInternal.cs
+++ b/CCL.Importer/Components/ControlNameTMPDisplayInternal.cs
@@ -1,0 +1,39 @@
+﻿using DV.CabControls;
+using TMPro;
+using UnityEngine;
+
+namespace CCL.Importer.Components
+{
+    internal class ControlNameTMPDisplayInternal : MonoBehaviour
+    {
+        public GameObject ControlObject = null!;
+        public TMP_Text Text = null!;
+
+        private ControlImplBase _control = null!;
+
+        private void Start()
+        {
+            if (!ControlObject || !ControlObject.TryGetComponent(out _control))
+            {
+                Debug.LogError("ControlNameTMPDisplay has no control assigned!");
+                Destroy(this);
+                return;
+            }
+
+            if (!Text)
+            {
+                Debug.LogError("ControlNameTMPDisplay has no text assigned!");
+                Destroy(this);
+                return;
+            }
+
+            Text.text = _control.GetCurrentPositionName().value;
+            _control.ValueChanged += UpdateText;
+        }
+
+        private void UpdateText(ValueChangedEventArgs _)
+        {
+            Text.text = _control.GetCurrentPositionName().value;
+        }
+    }
+}

--- a/CCL.Importer/Components/CustomComponentReplacer.cs
+++ b/CCL.Importer/Components/CustomComponentReplacer.cs
@@ -6,7 +6,6 @@ using CCL.Types.Components;
 using CCL.Types.Components.Headlights;
 using CCL.Types.Components.Indicators;
 using CCL.Types.Components.Simulation;
-using System;
 
 namespace CCL.Importer.Components
 {
@@ -18,6 +17,8 @@ namespace CCL.Importer.Components
             MapHeadlights();
             MapIndicators();
             MapSimulation();
+
+            CreateMap<ControlNameTMPDisplay, ControlNameTMPDisplayInternal>().AutoCacheAndMap();
         }
 
         private void MapCoupling()
@@ -37,6 +38,7 @@ namespace CCL.Importer.Components
         private void MapIndicators()
         {
             CreateMap<IndicatorShaderCustomValue, IndicatorShaderCustomValueInternal>().AutoCacheAndMap();
+            CreateMap<IndicatorTMP, IndicatorTMPInternal>().AutoCacheAndMap();
         }
 
         private void MapSimulation()
@@ -44,6 +46,7 @@ namespace CCL.Importer.Components
             CreateMap<TickingOutputDefinition, TickingOutputDefinitionInternal>().AutoCacheAndMap();
             CreateMap<FuseInverterDefinition, FuseInverterDefinitionInternal>().AutoCacheAndMap()
                 .AfterMap(FuseInverterAfter);
+            CreateMap<CombinedThrottleDynamicBrakeDefinition, CombinedThrottleDynamicBrakeDefinitionInternal>().AutoCacheAndMap();
         }
 
         private void FuseInverterAfter(FuseInverterDefinition fake, FuseInverterDefinitionInternal real)

--- a/CCL.Importer/Components/CustomComponentReplacer.cs
+++ b/CCL.Importer/Components/CustomComponentReplacer.cs
@@ -19,6 +19,7 @@ namespace CCL.Importer.Components
             MapSimulation();
 
             CreateMap<ControlNameTMPDisplay, ControlNameTMPDisplayInternal>().AutoCacheAndMap();
+            CreateMap<HideObjectsOnCargoLoad, HideObjectsOnCargoLoadInternal>().AutoCacheAndMap();
         }
 
         private void MapCoupling()

--- a/CCL.Importer/Components/HideObjectsOnCargoLoadInternal.cs
+++ b/CCL.Importer/Components/HideObjectsOnCargoLoadInternal.cs
@@ -1,0 +1,55 @@
+﻿using DV.ThingTypes;
+using UnityEngine;
+
+namespace CCL.Importer.Components
+{
+    internal class HideObjectsOnCargoLoadInternal : MonoBehaviour
+    {
+        public GameObject[] Objects = new GameObject[0];
+
+        private TrainCar _car = null!;
+
+        private void Start()
+        {
+            _car = TrainCar.Resolve(gameObject);
+
+            if (_car == null)
+            {
+                Debug.LogError("Could not find TrainCar for HideObjectsOnCargoLoad!");
+                Destroy(this);
+                return;
+            }
+
+            _car.CargoLoaded += Hide;
+            _car.CargoUnloaded += Show;
+        }
+
+        private void OnDestroy()
+        {
+            _car.CargoLoaded -= Hide;
+            _car.CargoUnloaded -= Show;
+        }
+
+        public void Hide(CargoType type)
+        {
+            if (type == CargoType.None)
+            {
+                Show();
+                return;
+            }
+
+            foreach (GameObject obj in Objects)
+            {
+                obj.SetActive(false);
+            }
+        }
+
+        public void Show()
+        {
+            foreach (GameObject obj in Objects)
+            {
+                obj.SetActive(true);
+            }
+        }
+    }
+}

--- a/CCL.Importer/Components/Indicators/IndicatorTMPInternal.cs
+++ b/CCL.Importer/Components/Indicators/IndicatorTMPInternal.cs
@@ -1,0 +1,34 @@
+﻿using CCL.Types.Components.Indicators;
+using TMPro;
+using UnityEngine;
+
+namespace CCL.Importer.Components.Indicators
+{
+    internal class IndicatorTMPInternal : Indicator
+    {
+        public TMP_Text Text = null!;
+        public IndicatorTMP.Mode DisplayMode;
+        public string Suffix = string.Empty;
+        public string[] Names = new string[0];
+
+        private int RoundedValue => Mathf.RoundToInt(Value);
+
+        protected override void OnValueSet()
+        {
+            Text.text = DisplayMode switch
+            {
+                IndicatorTMP.Mode.Value => Value.ToString("F2") + Suffix,
+                IndicatorTMP.Mode.RoundedValue => RoundedValue.ToString("F0") + Suffix,
+                IndicatorTMP.Mode.Names => GetNameFromValue() + Suffix,
+                _ => string.Empty,
+            };
+        }
+
+        private string GetNameFromValue()
+        {
+            return Names[
+                Mathf.RoundToInt(
+                    NumberUtil.MapClamp(Value, minValue, maxValue, 0, Names.Length - 1))];
+        }
+    }
+}

--- a/CCL.Importer/Components/Simulation/CombinedThrottleDynamicBrakeDefinitionInternal.cs
+++ b/CCL.Importer/Components/Simulation/CombinedThrottleDynamicBrakeDefinitionInternal.cs
@@ -1,0 +1,22 @@
+﻿using CCL.Importer.Implementations;
+using LocoSim.Definitions;
+using LocoSim.Implementations;
+
+namespace CCL.Importer.Components.Simulation
+{
+    internal class CombinedThrottleDynamicBrakeDefinitionInternal : SimComponentDefinition
+    {
+        public bool UseToggleMode = false;
+
+        public readonly PortDefinition ThrottleIn = new(PortType.EXTERNAL_IN, PortValueType.CONTROL, "THROTTLE_EXT_IN");
+        public readonly PortDefinition DynBrakeIn = new(PortType.EXTERNAL_IN, PortValueType.CONTROL, "DYNAMIC_BRAKE_EXT_IN");
+        public readonly PortDefinition CombinedIn = new(PortType.EXTERNAL_IN, PortValueType.CONTROL, "COMBINED_EXT_IN");
+        public readonly PortDefinition SelectorIn = new(PortType.EXTERNAL_IN, PortValueType.CONTROL, "SELECTOR_EXT_IN");
+        public readonly PortDefinition CurrentMode = new(PortType.READONLY_OUT, PortValueType.STATE, "CURRENT_MODE");
+
+        public override SimComponent InstantiateImplementation()
+        {
+            return new CombinedThrottleDynamicBrake(this);
+        }
+    }
+}

--- a/CCL.Importer/Implementations/CombinedThrottleDynamicBrake.cs
+++ b/CCL.Importer/Implementations/CombinedThrottleDynamicBrake.cs
@@ -1,0 +1,116 @@
+﻿using CCL.Importer.Components.Simulation;
+using LocoSim.Implementations;
+
+namespace CCL.Importer.Implementations
+{
+    internal class CombinedThrottleDynamicBrake : SimComponent
+    {
+        public readonly bool UseToggleMode;
+        public readonly Port ThrottleIn;
+        public readonly Port DynBrakeIn;
+        public readonly Port CombinedIn;
+        public readonly Port SelectorIn;
+        public readonly Port CurrentMode;
+
+        private int _mode;
+
+        public CombinedThrottleDynamicBrake(CombinedThrottleDynamicBrakeDefinitionInternal def) : base(def.ID)
+        {
+            UseToggleMode = def.UseToggleMode;
+
+            ThrottleIn = AddPort(def.ThrottleIn);
+            DynBrakeIn = AddPort(def.DynBrakeIn);
+            CombinedIn = AddPort(def.CombinedIn);
+            SelectorIn = AddPort(def.SelectorIn, 0.5f);
+            CurrentMode = AddPort(def.CurrentMode);
+
+            ThrottleIn.ValueUpdatedInternally += ThrottleUpdated;
+            DynBrakeIn.ValueUpdatedInternally += DynBrakeUpdated;
+            CombinedIn.ValueUpdatedInternally += CombinedUpdated;
+            SelectorIn.ValueUpdatedInternally += SelectorUpdated;
+
+            _mode = 0;
+        }
+
+        public override void Tick(float delta) { }
+
+        private void ThrottleUpdated(float value)
+        {
+            if (_mode == 1)
+            {
+                CombinedIn.Value = value;
+            }
+        }
+
+        private void DynBrakeUpdated(float value)
+        {
+            if (_mode == -1)
+            {
+                CombinedIn.Value = value;
+            }
+        }
+
+        private void CombinedUpdated(float value)
+        {
+            switch (_mode)
+            {
+                case 1:
+                    ThrottleIn.Value = value;
+                    DynBrakeIn.Value = 0;
+                    break;
+                case -1:
+                    ThrottleIn.Value = 0;
+                    DynBrakeIn.Value = value;
+                    break;
+                default:
+                    ThrottleIn.Value = 0;
+                    DynBrakeIn.Value = 0;
+                    break;
+            }
+        }
+
+        private void SelectorUpdated(float value)
+        {
+            if (UseToggleMode)
+            {
+                // Toggle goes up when set forwards, then it goes back to neutral.
+                // Same for the opposite direction, and clamp to [-1..1].
+                if (value > 0.75f)
+                {
+                    _mode++;
+
+                    if (_mode > 1)
+                    {
+                        _mode = 1;
+                    }
+                }
+                else if (value < 0.25f)
+                {
+                    _mode--;
+
+                    if (_mode < -1)
+                    {
+                        _mode = -1;
+                    }
+                }
+            }
+            else
+            {
+                if (value > 0.75f)
+                {
+                    _mode = 1;
+                }
+                else if (value < 0.25f)
+                {
+                    _mode = -1;
+                }
+                else
+                {
+                    _mode = 0;
+                }
+            }
+
+            CurrentMode.Value = _mode;
+        }
+    }
+}

--- a/CCL.Importer/Processing/SimulationProcessor.cs
+++ b/CCL.Importer/Processing/SimulationProcessor.cs
@@ -119,6 +119,7 @@ namespace CCL.Importer.Processing
             AddController<PositionSyncProviderController, PositionSyncProvider>(prefab);
             AddController<PositionSyncConsumerController, PositionSyncConsumer>(prefab);
             AddController<OilingPointsPortController, OilingPointPortFeederReader>(prefab);
+            AddController<ControlsBlockController, ControlBlocker>(prefab);
 
             // Add more wrapper controllers here - or possibly use MEF to initialize wrapper controllers?
         }

--- a/CCL.Importer/Proxies/Indicators/IndicatorProxyMapper.cs
+++ b/CCL.Importer/Proxies/Indicators/IndicatorProxyMapper.cs
@@ -33,6 +33,7 @@ namespace CCL.Importer.Proxies.Indicators
                 .ForMember(d => d.lampInd, o => o.MapFrom(s => Mapper.GetFromCache(s.lampInd)))
                 .ForMember(d => d.lampAudioMixerGroup, o => o.MapFrom(s => s.audioMixerGroup.ToInstance()));
             CreateMap<LampWheelSlipSlideReaderProxy, LampWheelSlipSlideReader>().AutoCacheAndMap();
+            CreateMap<LampControllerTemperatureMUProxy, LampControllerTemperatureMU>().AutoCacheAndMap();
 
             CreateMap<LabelLocalizer, Localize>();
         }

--- a/CCL.Types/CCL.Types.csproj
+++ b/CCL.Types/CCL.Types.csproj
@@ -7,6 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<Reference Include="Unity.TextMeshPro" />
 		<Reference Include="UnityEngine" />
 		<Reference Include="UnityEngine.AssetBundleModule" />
 		<Reference Include="UnityEngine.AnimationModule" />

--- a/CCL.Types/Components/ControlNameTMPDisplay.cs
+++ b/CCL.Types/Components/ControlNameTMPDisplay.cs
@@ -1,0 +1,11 @@
+﻿using TMPro;
+using UnityEngine;
+
+namespace CCL.Types.Components
+{
+    public class ControlNameTMPDisplay : MonoBehaviour
+    {
+        public GameObject ControlObject = null!;
+        public TMP_Text Text = null!;
+    }
+}

--- a/CCL.Types/Components/HideObjectsOnCargoLoad.cs
+++ b/CCL.Types/Components/HideObjectsOnCargoLoad.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Components
+{
+    public class HideObjectsOnCargoLoad : MonoBehaviour
+    {
+        public GameObject[] Objects = new GameObject[0];
+    }
+}

--- a/CCL.Types/Components/Indicators/IndicatorTMP.cs
+++ b/CCL.Types/Components/Indicators/IndicatorTMP.cs
@@ -1,0 +1,20 @@
+﻿using CCL.Types.Proxies.Indicators;
+using TMPro;
+
+namespace CCL.Types.Components.Indicators
+{
+    public class IndicatorTMP : IndicatorProxy
+    {
+        public enum Mode
+        {
+            Value,
+            RoundedValue,
+            Names
+        }
+
+        public TMP_Text Text = null!;
+        public Mode DisplayMode;
+        public string Suffix = string.Empty;
+        public string[] Names = new string[0];
+    }
+}

--- a/CCL.Types/Components/Simulation/CombinedThrottleDynamicBrakeDefinition.cs
+++ b/CCL.Types/Components/Simulation/CombinedThrottleDynamicBrakeDefinition.cs
@@ -1,0 +1,19 @@
+﻿using CCL.Types.Proxies.Ports;
+using System.Collections.Generic;
+
+namespace CCL.Types.Components.Simulation
+{
+    public class CombinedThrottleDynamicBrakeDefinition : SimComponentDefinitionProxy
+    {
+        public bool UseToggleMode = false;
+
+        public override IEnumerable<PortDefinition> ExposedPorts => new[]
+        {
+            new PortDefinition(DVPortType.EXTERNAL_IN, DVPortValueType.CONTROL, "THROTTLE_EXT_IN"),
+            new PortDefinition(DVPortType.EXTERNAL_IN, DVPortValueType.CONTROL, "DYNAMIC_BRAKE_EXT_IN"),
+            new PortDefinition(DVPortType.EXTERNAL_IN, DVPortValueType.CONTROL, "COMBINED_EXT_IN"),
+            new PortDefinition(DVPortType.EXTERNAL_IN, DVPortValueType.CONTROL, "SELECTOR_EXT_IN"),
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.STATE, "CURRENT_MODE")
+        };
+    }
+}

--- a/CCL.Types/Proxies/Indicators/LampControllerTemperatureMUProxy.cs
+++ b/CCL.Types/Proxies/Indicators/LampControllerTemperatureMUProxy.cs
@@ -4,15 +4,8 @@ using UnityEngine;
 
 namespace CCL.Types.Proxies.Indicators
 {
-    public class LampWheelSlipSlideReaderProxy : MonoBehaviour, IHasFuseIdFields
+    public class LampControllerTemperatureMUProxy : MonoBehaviour, IHasFuseIdFields
     {
-        public enum WheelslipDetectionMode
-        {
-            Individual,
-            MultipleUnit
-        }
-
-        public WheelslipDetectionMode wheelslipDetectionMode;
         [FuseId]
         public string fuseId = string.Empty;
 

--- a/CCL.Types/Proxies/Ports/SimConnectionsDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Ports/SimConnectionsDefinitionProxy.cs
@@ -8,17 +8,14 @@ namespace CCL.Types.Proxies.Ports
 {
     public class SimConnectionsDefinitionProxy : MonoBehaviour, ICustomSerialized
     {
-        public List<SimComponentDefinitionProxy> executionOrder;
-
-        public List<PortConnectionProxy> connections;
-
-        [SerializeField, HideInInspector]
-        private string connectionsJson;
-
-        public List<PortReferenceConnectionProxy> portReferenceConnections;
+        public List<SimComponentDefinitionProxy> executionOrder = new List<SimComponentDefinitionProxy>();
+        public List<PortConnectionProxy> connections = new List<PortConnectionProxy>();
+        public List<PortReferenceConnectionProxy> portReferenceConnections = new List<PortReferenceConnectionProxy>();
 
         [SerializeField, HideInInspector]
-        private string portReferenceConnectionsJson;
+        private string? connectionsJson;
+        [SerializeField, HideInInspector]
+        private string? portReferenceConnectionsJson;
 
         public void OnValidate()
         {
@@ -32,7 +29,6 @@ namespace CCL.Types.Proxies.Ports
             portReferenceConnections = JSONObject.FromJson(portReferenceConnectionsJson, () => new List<PortReferenceConnectionProxy>());
         }
 
-        
         public void PopulateComponents()
         {
             executionOrder ??= new List<SimComponentDefinitionProxy>();
@@ -45,6 +41,14 @@ namespace CCL.Types.Proxies.Ports
                     executionOrder.Add(component);
                 }
             }
+        }
+
+        public void AutoSort()
+        {
+            executionOrder ??= new List<SimComponentDefinitionProxy>();
+            var allComponents = transform.root.GetComponentsInChildren<SimComponentDefinitionProxy>();
+
+            executionOrder = executionOrder.OrderBy(x => Array.IndexOf(allComponents, x)).ToList();
         }
 
         public void DestroyConnectionsToComponent(SimComponentDefinitionProxy component)
@@ -137,19 +141,17 @@ namespace CCL.Types.Proxies.Ports
     public class PortConnectionProxy
     {
         [PortId(DVPortType.OUT)]
-        public string fullPortIdOut;
-
+        public string fullPortIdOut = string.Empty;
         [PortId(DVPortType.IN)]
-        public string fullPortIdIn;
+        public string fullPortIdIn = string.Empty;
     }
 
     [Serializable]
     public class PortReferenceConnectionProxy
     {
         [PortReferenceId]
-        public string portReferenceId;
-
+        public string portReferenceId = string.Empty;
         [PortId]
-        public string portId;
+        public string portId = string.Empty;
     }
 }


### PR DESCRIPTION
Added combined throttle/dynamic brake sim component.
* This uses a port to decide whether another port controls the throttle or dynamic brake.
* Has 2 selector behaviours:
  * Toggle, which cycles the modes.
  * Not toggle, which directly uses the value to set the mode.

Added IndicatorTMP.
* This can display either the raw value, a rounded value, or the display name of a control.

Added missing control blocker controller.
Added LampControllerTemperatureMUProxy.
Added a component that can hide GameObjects when cargo is loaded.
Improved SimConnectionsDefinitionProxy inspector.
Improved SimComponentInspector.