### PR TITLE
MU Extensions

### DIFF
--- a/CCL.Creator/Wizards/ParticleWizards.cs
+++ b/CCL.Creator/Wizards/ParticleWizards.cs
@@ -245,10 +245,10 @@ namespace CCL.Creator.Wizards
             cylCockDrip.transform.parent = comp.transform;
             var dripL = new GameObject("CylCockWaterDrip L").AddComponent<CopyVanillaParticleSystem>();
             dripL.transform.parent = cylCockDrip.transform;
-            dripL.SystemToCopy = VanillaParticleSystem.SteamerCylCockWaterDripParticles;
+            dripL.SystemToCopy = VanillaParticleSystem.SteamerCylCockWaterDrip;
             var dripR = new GameObject("CylCockWaterDrip R").AddComponent<CopyVanillaParticleSystem>();
             dripR.transform.parent = cylCockDrip.transform;
-            dripR.SystemToCopy = VanillaParticleSystem.SteamerCylCockWaterDripParticles;
+            dripR.SystemToCopy = VanillaParticleSystem.SteamerCylCockWaterDrip;
 
             var cylCockSteam = new GameObject("CylCockSteam").AddComponent<CylinderCockParticlePortReaderProxy>();
             cylCockSteam.transform.parent = comp.transform;

--- a/CCL.Creator/Wizards/WizardlessWizards.cs
+++ b/CCL.Creator/Wizards/WizardlessWizards.cs
@@ -62,8 +62,6 @@ namespace CCL.Creator.Wizards
 
             var box = tp.AddComponent<BoxCollider>();
             var reaction = tp.AddComponent<InvalidTeleportLocationReactionProxy>();
-            reaction.waitBeforeSpawn = 0.5f;
-            reaction.drawAttentionPointLine = true;
             reaction.blocker = comp;
 
             Undo.RegisterCreatedObjectUndo(blocker, "Created License Blocker");

--- a/CCL.Importer/Components/CustomComponentReplacer.cs
+++ b/CCL.Importer/Components/CustomComponentReplacer.cs
@@ -1,10 +1,12 @@
 ﻿using AutoMapper;
 using CCL.Importer.Components.Headlights;
 using CCL.Importer.Components.Indicators;
+using CCL.Importer.Components.MultipleUnit;
 using CCL.Importer.Components.Simulation;
 using CCL.Types.Components;
 using CCL.Types.Components.Headlights;
 using CCL.Types.Components.Indicators;
+using CCL.Types.Components.MultipleUnit;
 using CCL.Types.Components.Simulation;
 
 namespace CCL.Importer.Components
@@ -17,6 +19,7 @@ namespace CCL.Importer.Components
             MapHeadlights();
             MapIndicators();
             MapSimulation();
+            MapMultipleUnit();
 
             CreateMap<ControlNameTMPDisplay, ControlNameTMPDisplayInternal>().AutoCacheAndMap();
             CreateMap<HideObjectsOnCargoLoad, HideObjectsOnCargoLoadInternal>().AutoCacheAndMap();
@@ -49,6 +52,11 @@ namespace CCL.Importer.Components
             CreateMap<FuseInverterDefinition, FuseInverterDefinitionInternal>().AutoCacheAndMap()
                 .AfterMap(FuseInverterAfter);
             CreateMap<CombinedThrottleDynamicBrakeDefinition, CombinedThrottleDynamicBrakeDefinitionInternal>().AutoCacheAndMap();
+        }
+
+        private void MapMultipleUnit()
+        {
+            CreateMap<MultipleUnitCombinedThrottleDynamicBrakeMode, MultipleUnitCombinedThrottleDynamicBrakeModeInternal>().AutoCacheAndMap();
         }
 
         private void FuseInverterAfter(FuseInverterDefinition fake, FuseInverterDefinitionInternal real)

--- a/CCL.Importer/Components/MultipleUnit/MultipleUnitCombinedThrottleDynamicBrakeModeInternal.cs
+++ b/CCL.Importer/Components/MultipleUnit/MultipleUnitCombinedThrottleDynamicBrakeModeInternal.cs
@@ -1,0 +1,32 @@
+﻿using LocoSim.Implementations;
+using UnityEngine;
+
+namespace CCL.Importer.Components.MultipleUnit
+{
+    public class MultipleUnitCombinedThrottleDynamicBrakeModeInternal :
+        MultipleUnitExtraControlInternal<MultipleUnitCombinedThrottleDynamicBrakeModeInternal>
+    {
+        public string ModePortId = string.Empty;
+
+        private Port _modePort = null!;
+
+        public override void Init(TrainCar car, SimulationFlow simFlow)
+        {
+            base.Init(car, simFlow);
+
+            if (!simFlow.TryGetPort(ModePortId, out _modePort, false))
+            {
+                Debug.LogError($"(MultipleUnitCombinedThrottleDynamicBrakeMode) Could not find mode port!", this);
+                Destroy(this);
+                return;
+            }
+
+            _modePort.ValueUpdatedInternally += (x) => ValueChanged();
+        }
+
+        public override void SetValue(MultipleUnitCombinedThrottleDynamicBrakeModeInternal source)
+        {
+            _modePort.Value = source._modePort.Value;
+        }
+    }
+}

--- a/CCL.Importer/Components/MultipleUnit/MultipleUnitExtraControlInternal.cs
+++ b/CCL.Importer/Components/MultipleUnit/MultipleUnitExtraControlInternal.cs
@@ -1,0 +1,76 @@
+﻿using DV.MultipleUnit;
+using DV.Simulation.Controllers;
+using LocoSim.Implementations;
+using UnityEngine;
+
+namespace CCL.Importer.Components.MultipleUnit
+{
+    public abstract class MultipleUnitExtraControlInternal<T> : ASimInitializedController
+        where T : MultipleUnitExtraControlInternal<T>
+    {
+        private MultipleUnitModule _module = null!;
+
+        public override void Init(TrainCar car, SimulationFlow simFlow)
+        {
+            _module = car.muModule;
+
+            if (_module == null)
+            {
+                Debug.LogError("(MultipleUnitExtraControl) TrainCar has no muModule!");
+                Destroy(this);
+                return;
+            }
+        }
+
+        public abstract void SetValue(T source);
+
+        public void ValueChanged()
+        {
+            switch (_module.Mode)
+            {
+                case MultipleUnitModule.MultipleUnitMode.CABLE:
+                    PropagateThroughCable(true);
+                    PropagateThroughCable(false);
+                    break;
+                case MultipleUnitModule.MultipleUnitMode.RADIO:
+                    if (_module.RemoteChannel.Transmitter != this)
+                    {
+                        return;
+                    }
+
+                    foreach (var device in _module.RemoteChannel.devices)
+                    {
+                        TrySetValue(device);
+                    }
+                    break;
+                default:
+                    Debug.LogError($"Unexpected mode: {_module.Mode}! Ignoring");
+                    break;
+            }
+        }
+
+        private void PropagateThroughCable(bool direction)
+        {
+            var module = _module;
+
+            while (module != null)
+            {
+                var cable = direction ? module.FrontCable : module.RearCable;
+
+                if (!cable.IsConnected) return;
+
+                direction = !cable.connectedTo.isFront;
+                module = cable.connectedTo.muModule;
+                TrySetValue(module);
+            }
+        }
+
+        private void TrySetValue(MultipleUnitModule module)
+        {
+            if (module != this && module.train.TryGetComponent(out T comp))
+            {
+                comp.SetValue((T)this);
+            }
+        }
+    }
+}

--- a/CCL.Importer/Implementations/CombinedThrottleDynamicBrake.cs
+++ b/CCL.Importer/Implementations/CombinedThrottleDynamicBrake.cs
@@ -1,5 +1,6 @@
 ﻿using CCL.Importer.Components.Simulation;
 using LocoSim.Implementations;
+using UnityEngine;
 
 namespace CCL.Importer.Implementations
 {
@@ -28,6 +29,7 @@ namespace CCL.Importer.Implementations
             DynBrakeIn.ValueUpdatedInternally += DynBrakeUpdated;
             CombinedIn.ValueUpdatedInternally += CombinedUpdated;
             SelectorIn.ValueUpdatedInternally += SelectorUpdated;
+            CurrentMode.ValueUpdatedInternally += ModeUpdated;
 
             _mode = 0;
         }
@@ -111,6 +113,20 @@ namespace CCL.Importer.Implementations
             }
 
             CurrentMode.Value = _mode;
+        }
+
+        private void ModeUpdated(float value)
+        {
+            int mode = Mathf.RoundToInt(Mathf.Clamp(value, -1, 1));
+
+            if (mode == _mode) return;
+
+            _mode = mode;
+
+            if (!UseToggleMode)
+            {
+                SelectorIn.Value = _mode + 1.0f / 2.0f;
+            }
         }
     }
 }

--- a/CCL.Importer/Processing/LabelProcessor.cs
+++ b/CCL.Importer/Processing/LabelProcessor.cs
@@ -1,4 +1,5 @@
-﻿using CCL.Types.Proxies.Indicators;
+﻿using CCL.Types;
+using CCL.Types.Proxies.Indicators;
 using DV.Localization;
 using System.ComponentModel.Composition;
 using UnityEngine;
@@ -42,25 +43,23 @@ namespace CCL.Importer.Processing
                         // create new holder for text and model
                         var holder = new GameObject($"{labelProxy.gameObject.name}_text");
                         holder.transform.SetParent(labelProxy.transform.parent, false);
-                        holder.transform.localPosition = labelProxy.transform.localPosition;
-                        holder.transform.localRotation = labelProxy.transform.localRotation;
+                        holder.transform.CopyLocal(labelProxy.transform);
 
                         // reparent original text obj to holder
                         labelProxy.transform.SetParent(holder.transform, false);
-                        labelProxy.transform.localPosition = Vector3.zero;
-                        labelProxy.transform.localRotation = Quaternion.identity;
+                        labelProxy.transform.Reset();
 
                         if (labelProxy.ModelType.HasFlag(LabelModelType.Offset))
                         {
                             GameObject toCopy = useDefaultText ? _offsetLabelComplete : _offsetLabelModel;
-                            var instantiated = UnityEngine.Object.Instantiate(toCopy, holder.transform, false);
+                            var instantiated = Object.Instantiate(toCopy, holder.transform, false);
                             instantiated.transform.localPosition = Vector3.zero;
                             instantiated.transform.localRotation = _labelModelRotation;
                         }
                         else if (labelProxy.ModelType.HasFlag(LabelModelType.Flush))
                         {
                             GameObject toCopy = useDefaultText ? _flushLabelComplete : _flushLabelModel;
-                            var instantiated = UnityEngine.Object.Instantiate(toCopy, holder.transform, false);
+                            var instantiated = Object.Instantiate(toCopy, holder.transform, false);
                             instantiated.transform.localPosition = Vector3.zero;
                             instantiated.transform.localRotation = _labelModelRotation;
                         }

--- a/CCL.Importer/Processing/ObjectInstancerProcessor.cs
+++ b/CCL.Importer/Processing/ObjectInstancerProcessor.cs
@@ -113,7 +113,7 @@ namespace CCL.Importer.Processing
                     "LocoS282A_Particles/SteamSmoke/SmokeEmbers/EmberSparks").GetComponent<ParticleSystem>(),
 
 
-                VanillaParticleSystem.SteamerCylCockWaterDripParticles  => TrainCarType.LocoSteamHeavy.ToV2().prefab.transform.Find(
+                VanillaParticleSystem.SteamerCylCockWaterDrip  => TrainCarType.LocoSteamHeavy.ToV2().prefab.transform.Find(
                     "LocoS282A_Particles/CylCockWaterDrip/CylCockWaterDrip L/CylCockWaterDripParticles").GetComponent<ParticleSystem>(),
 
 

--- a/CCL.Types/Components/CopyVanillaParticleSystem.cs
+++ b/CCL.Types/Components/CopyVanillaParticleSystem.cs
@@ -25,7 +25,7 @@ namespace CCL.Types.Components
         SteamerSteamSmokeThick,
         SteamerEmberClusters,
         SteamerEmberSparks,
-        SteamerCylCockWaterDripParticles = 120,
+        SteamerCylCockWaterDrip = 120,
         SteamerExhaustSmallWispy = 150,
         SteamerExhaustSmallWave,
         SteamerExhaustWispy,

--- a/CCL.Types/Components/MultipleUnit/MultipleUnitCombinedThrottleDynamicBrakeMode.cs
+++ b/CCL.Types/Components/MultipleUnit/MultipleUnitCombinedThrottleDynamicBrakeMode.cs
@@ -1,0 +1,17 @@
+﻿using CCL.Types.Proxies.Ports;
+using System.Collections.Generic;
+
+namespace CCL.Types.Components.MultipleUnit
+{
+    public class MultipleUnitCombinedThrottleDynamicBrakeMode :
+        MultipleUnitExtraControl<MultipleUnitCombinedThrottleDynamicBrakeMode>, IHasPortIdFields
+    {
+        [PortId]
+        public string ModePortId = string.Empty;
+
+        public IEnumerable<PortIdField> ExposedPortIdFields => new[]
+        {
+            new PortIdField(this, nameof(ModePortId), ModePortId, DVPortType.READONLY_OUT, DVPortValueType.STATE),
+        };
+    }
+}

--- a/CCL.Types/Components/MultipleUnit/MultipleUnitExtraControl.cs
+++ b/CCL.Types/Components/MultipleUnit/MultipleUnitExtraControl.cs
@@ -1,0 +1,7 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Components.MultipleUnit
+{
+    public abstract class MultipleUnitExtraControl<T> : MonoBehaviour
+        where T : MultipleUnitExtraControl<T> { }
+}

--- a/CCL.Types/Extensions.cs
+++ b/CCL.Types/Extensions.cs
@@ -75,5 +75,12 @@ namespace CCL.Types
             transform.localRotation = Quaternion.identity;
             transform.localScale = Vector3.one;
         }
+
+        public static void CopyLocal(this Transform target, Transform source)
+        {
+            target.localPosition = source.localPosition;
+            target.localRotation = source.localRotation;
+            target.localScale = source.localScale;
+        }
     }
 }

--- a/CCL.Types/Proxies/InvalidTeleportLocationReactionProxy.cs
+++ b/CCL.Types/Proxies/InvalidTeleportLocationReactionProxy.cs
@@ -4,8 +4,6 @@ namespace CCL.Types.Proxies
 {
     public class InvalidTeleportLocationReactionProxy : MonoBehaviour
     {
-        public ZoneBlockerProxy blocker;
-        public float waitBeforeSpawn = 1f;
-        public bool drawAttentionPointLine = true;
+        public ZoneBlockerProxy blocker = null!;
     }
 }


### PR DESCRIPTION
Added a way to share other controls and ports over MU cables and gadgets.
* This works with both cable and wireless MU.
  * As a note, the way this works is changed in B99.4 (to not be mutually exclusive), and has been updated in a later PR.
* Only implementation ATM if for the combined throttle/dynamic brake component.
* Could be used to also share gear levers/steamer controls in future.

Updated vanilla particle names.
Updated InvalidTeleportLocationReactionProxy.
Updated labels to allow scaling.