### PR TITLE
Procedural Material Generator

### DIFF
--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -170,6 +170,8 @@ namespace CCL.Importer
 
                 // Load paints.
                 PaintLoader.LoadSubstitutions(serializedCar.PaintSubstitutions);
+                // Generate procedural materials.
+                ProceduralMaterialGenerator.Generate(serializedCar.ProceduralMaterials);
 
                 CCLPlugin.Log($"Successfully loaded car type {carId}");
 

--- a/CCL.Importer/ProceduralMaterialGenerator.cs
+++ b/CCL.Importer/ProceduralMaterialGenerator.cs
@@ -1,0 +1,81 @@
+﻿using CCL.Types;
+using CCL.Types.Components.Materials;
+using UnityEngine;
+
+namespace CCL.Importer
+{
+    internal static class ProceduralMaterialGenerator
+    {
+        private static class ShaderProps
+        {
+            // Standard
+            public static readonly int MainTex = Shader.PropertyToID("_MainTex");
+            public static readonly int OcclusionStrength = Shader.PropertyToID("_OcclusionStrength");
+            public static readonly int OcclusionMap = Shader.PropertyToID("_OcclusionMap");
+
+            // DV/SightGlass
+            public static readonly int SightGlassThickness = Shader.PropertyToID("_PipeThickness");
+            public static readonly int SightGlassGlass = Shader.PropertyToID("_GlassDetail");
+            public static readonly int SightGlassWaterTint = Shader.PropertyToID("_WaterTint");
+            public static readonly int SightGlassGlassTint = Shader.PropertyToID("_GlassTint");
+        }
+
+        public static void Generate(ProceduralMaterialDefinitions? definitions)
+        {
+            if (definitions == null) return;
+
+            foreach (var definition in definitions.Entries)
+            {
+                Generate(definition);
+            }
+        }
+
+        private static void Generate(ProceduralMaterialDefinitions.GeneratorSet definition)
+        {
+            switch (definition.Type)
+            {
+                case ProceduralMaterialDefinitions.MaterialType.Exploded:
+                    GenerateExploded(definition.Original);
+                    return;
+                default:
+                    return;
+            }
+        }
+
+        public static void GenerateExploded(Material original)
+        {
+            var strength = original.GetFloat(ShaderProps.OcclusionStrength);
+            var map = original.GetTexture(ShaderProps.OcclusionMap);
+
+            original.CopyPropertiesFromMaterial(QuickAccess.Materials.ExplodedDE2Cab);
+            original.SetFloat(ShaderProps.OcclusionStrength, strength);
+            original.SetTexture(ShaderProps.OcclusionMap, map);
+        }
+
+        public static Material GenerateMaterial(IGeneratedMaterial generator)
+        {
+            return generator switch
+            {
+                GenerateSightGlass sightglass => GenerateSightGlassMat(sightglass),
+                _ => null!,
+            };
+        }
+
+        public static Material GenerateSightGlassMat(GenerateSightGlass settings)
+        {
+            if (GenerateSightGlass.TryGetAlreadyGenerated(settings, out var mat)) return mat;
+            
+            mat = new Material(QuickAccess.Materials.SightGlassS060);
+
+            mat.SetTextureScale(ShaderProps.MainTex, settings.BackgroundTextureTiling);
+            mat.SetTextureScale(ShaderProps.SightGlassGlass, settings.GlassTextureTiling);
+            mat.SetVector(ShaderProps.SightGlassWaterTint, settings.LiquidTint);
+            mat.SetVector(ShaderProps.SightGlassGlassTint, settings.GlassTint);
+            mat.SetFloat(ShaderProps.SightGlassThickness, settings.PipeThickness);
+
+            settings.Cache(mat);
+
+            return mat;
+        }
+    }
+}

--- a/CCL.Importer/Processing/ExternalInteractableProcessor.cs
+++ b/CCL.Importer/Processing/ExternalInteractableProcessor.cs
@@ -36,7 +36,7 @@ namespace CCL.Importer.Processing
             _flatbedHandbrake = flatbedInteractables.transform.Find(HANDBRAKE_SMALL).gameObject;
             _flatbedBrakeRelease = flatbedInteractables.transform.Find(BRAKE_CYL_RELEASE).gameObject;
 
-            _hopperHandbrake = QuickAccess.Wagons.Hopper.externalInteractablesPrefab
+            _hopperHandbrake = QuickAccess.Wagons.HopperBrown.externalInteractablesPrefab
                 .transform.Find(HANDBRAKE_HOPPER).gameObject;
 
             _s060Handbrake = QuickAccess.Locomotives.S060.interiorPrefab

--- a/CCL.Importer/Processing/MaterialProcessor.cs
+++ b/CCL.Importer/Processing/MaterialProcessor.cs
@@ -1,0 +1,27 @@
+﻿using CCL.Types.Components.Materials;
+using System.ComponentModel.Composition;
+using UnityEngine;
+
+namespace CCL.Importer.Processing
+{
+    [Export(typeof(IModelProcessorStep))]
+    internal class MaterialProcessor : ModelProcessorStep
+    {
+        public override void ExecuteStep(ModelProcessor context)
+        {
+            foreach (var item in context.Car.AllPrefabs)
+            {
+                ProcessAll(item);
+            }
+        }
+
+        public static void ProcessAll(GameObject prefab)
+        {
+            foreach (var item in prefab.GetComponentsInChildren<IGeneratedMaterial>())
+            {
+                ProceduralMaterialGenerator.GenerateMaterial(item);
+                item.Assign();
+            }
+        }
+    }
+}

--- a/CCL.Importer/Processing/ModelProcessor.cs
+++ b/CCL.Importer/Processing/ModelProcessor.cs
@@ -119,6 +119,7 @@ namespace CCL.Importer.Processing
             GrabberProcessor.ProcessGrabbersOnPrefab(prefab);
             ShaderProcessor.ReplaceShaderGrabbers(prefab);
             ObjectInstancerProcessor.ProcessAll(prefab);
+            MaterialProcessor.ProcessAll(prefab);
             Mapper.ProcessConfigs(prefab);
             Mapper.ClearComponentCache();
         }

--- a/CCL.Importer/QuickAccess.cs
+++ b/CCL.Importer/QuickAccess.cs
@@ -7,6 +7,9 @@ using UnityEngine;
 
 namespace CCL.Importer
 {
+    /// <summary>
+    /// Class for quick references to certain objects.
+    /// </summary>
     public static class QuickAccess
     {
         private static TrainCarLivery GetCarLivery(string id)
@@ -29,6 +32,9 @@ namespace CCL.Importer
             return car;
         }
 
+        /// <summary>
+        /// References to locomotive liveries.
+        /// </summary>
         public static class Locomotives
         {
             private static TrainCarLivery? s_de2;
@@ -58,17 +64,23 @@ namespace CCL.Importer
             public static TrainCarLivery Handcar => Extensions.GetCached(ref s_h1, () => GetCarLivery("LocoHandcar"));
         }
 
+        /// <summary>
+        /// References to wagon liveries.
+        /// </summary>
         public static class Wagons
         {
             private static TrainCarLivery? s_flatbed;
             private static TrainCarLivery? s_caboose;
-            private static TrainCarLivery? s_hopper;
+            private static TrainCarLivery? s_hopperBrown;
 
             public static TrainCarLivery Flatbed => Extensions.GetCached(ref s_flatbed, () => GetCarLivery("FlatbedEmpty"));
             public static TrainCarLivery Caboose => Extensions.GetCached(ref s_caboose, () => GetCarLivery("CabooseRed"));
-            public static TrainCarLivery Hopper => Extensions.GetCached(ref s_hopper, () => GetCarLivery("HopperBrown"));
+            public static TrainCarLivery HopperBrown => Extensions.GetCached(ref s_hopperBrown, () => GetCarLivery("HopperBrown"));
         }
 
+        /// <summary>
+        /// References to explosion prefabs.
+        /// </summary>
         public static class Explosions
         {
             private static DeadTractionMotorsController? s_de6deadTM;
@@ -111,6 +123,20 @@ namespace CCL.Importer
                 ExplosionPrefab.DieselLocomotive => DieselLocomotiveExplosion,
                 _ => null!
             };
+        }
+
+        /// <summary>
+        /// References to materials.
+        /// </summary>
+        public static class Materials
+        {
+            private static Material? s_explodedDE2cab;
+            private static Material? s_sightGlassS060;
+
+            public static Material ExplodedDE2Cab => Extensions.GetCached(ref s_explodedDE2cab,
+                () => Locomotives.DE2.explodedInteriorPrefab.transform.Find("Cab").GetComponent<Renderer>().sharedMaterial);
+            public static Material SightGlassS060 => Extensions.GetCached(ref s_sightGlassS060,
+                () => Locomotives.S060.interiorPrefab.transform.Find("Swivelables/WaterMeter/I_BoilerWater/sight_glass").GetComponent<Renderer>().sharedMaterial);
         }
     }
 }

--- a/CCL.Types/Components/Materials/GenerateSightGlass.cs
+++ b/CCL.Types/Components/Materials/GenerateSightGlass.cs
@@ -1,0 +1,24 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Components.Materials
+{
+    public class GenerateSightGlass : GeneratedMaterial<GenerateSightGlass>
+    {
+        public Vector2 BackgroundTextureTiling = new Vector2(1.0f, 6.0f);
+        public Vector2 GlassTextureTiling = new Vector2(0.2f, 1.0f);
+
+        public float PipeThickness = 0.5f;
+
+        public Color LiquidTint = new Color(0.6673193f, 0.7704878f, 0.8679245f, 1f);
+        public Color GlassTint = new Color(0.754717f, 0.6976369f, 0.494838f, 1f);
+
+        public override bool AreSameSettings(GenerateSightGlass other)
+        {
+            return BackgroundTextureTiling == other.BackgroundTextureTiling &&
+                GlassTextureTiling == other.GlassTextureTiling &&
+                PipeThickness == other.PipeThickness &&
+                LiquidTint == other.LiquidTint &&
+                GlassTint == other.GlassTint;
+        }
+    }
+}

--- a/CCL.Types/Components/Materials/GeneratedMaterial.cs
+++ b/CCL.Types/Components/Materials/GeneratedMaterial.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types.Components.Materials
+{
+    public interface IGeneratedMaterial
+    {
+        void Assign();
+    }
+
+    public abstract class GeneratedMaterial<T> : MonoBehaviour, IGeneratedMaterial
+        where T : GeneratedMaterial<T>
+    {
+        private static List<T> s_cache = new List<T>();
+
+        private Material _generated = null!;
+
+        public Renderer[] RenderersToAssign = new Renderer[0];
+
+        public abstract bool AreSameSettings(T other);
+
+        public void Cache(Material generated)
+        {
+            _generated = generated;
+            s_cache.Add((T)this);
+        }
+
+        public void Assign()
+        {
+            foreach (var renderer in RenderersToAssign)
+            {
+                renderer.sharedMaterial = _generated;
+            }
+        }
+
+        public static bool TryGetAlreadyGenerated(T comp, out Material mat)
+        {
+            for (int i = 0; i < s_cache.Count; i++)
+            {
+                var cached = s_cache[i];
+
+                if (cached == null)
+                {
+                    s_cache.RemoveAt(i);
+                    i--;
+                    continue;
+                }
+
+                if (comp.AreSameSettings(cached))
+                {
+                    comp._generated = cached._generated;
+                    mat = cached._generated;
+                    return true;
+                }
+            }
+
+            mat = null!;
+            return false;
+        }
+    }
+}

--- a/CCL.Types/CustomCarType.cs
+++ b/CCL.Types/CustomCarType.cs
@@ -83,6 +83,9 @@ namespace CCL.Types
         [Header("Paints - optional")]
         public PaintSubstitutions[] PaintSubstitutions = new PaintSubstitutions[0];
 
+        [Header("Procedural Material Generator - optional")]
+        public ProceduralMaterialDefinitions? ProceduralMaterials;
+
         [SerializeField, HideInInspector]
         private string? brakesJson;
         [SerializeField, HideInInspector]
@@ -167,6 +170,11 @@ namespace CCL.Types
             foreach (var item in PaintSubstitutions)
             {
                 item.AfterImport();
+            }
+
+            if (ProceduralMaterials != null)
+            {
+                ProceduralMaterials.AfterImport();
             }
         }
 

--- a/CCL.Types/MenuOrdering.cs
+++ b/CCL.Types/MenuOrdering.cs
@@ -10,6 +10,7 @@
         public const int HUDLayout = 101;
         public const int PaintSub = 102;
         public const int Catalog = 103;
+        public const int ProcMats = 104;
 
         public const int ExtraTranslations = 200;
     }

--- a/CCL.Types/ProceduralMaterialDefinitions.cs
+++ b/CCL.Types/ProceduralMaterialDefinitions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types
+{
+    [CreateAssetMenu(menuName = "CCL/Procedural Materials", order = MenuOrdering.ProcMats)]
+    public class ProceduralMaterialDefinitions : ScriptableObject, ICustomSerialized
+    {
+        public enum MaterialType
+        {
+            Exploded
+        }
+
+        [Serializable]
+        public class GeneratorSet
+        {
+            public MaterialType Type;
+            public Material Original = null!;
+        }
+
+        public List<GeneratorSet> Entries = new List<GeneratorSet>();
+
+        [SerializeField, HideInInspector]
+        private MaterialType[]? _types;
+        [SerializeField, HideInInspector]
+        private Material[]? _mats;
+
+        public void OnValidate()
+        {
+            int length = Entries.Count;
+            _types = new MaterialType[length];
+            _mats = new Material[length];
+
+            for (int i = 0; i < length; i++)
+            {
+                _types[i] = Entries[i].Type;
+                _mats[i] = Entries[i].Original;
+            }
+        }
+
+        public void AfterImport()
+        {
+            Entries.Clear();
+
+            if (_types == null || _mats == null) return;
+
+            for (int i = 0; i < _types.Length; i++)
+            {
+                Entries.Add(new GeneratorSet { Type = _types[i], Original = _mats[i] });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added procedural material generator.
Added 2 ways of generating procedural materials.
* Method 1 replaces properties in the material itself (used for exploded materials).
* Method 2 creates a copy of another material and changes those properties (used for sightglasses).

Renamed Hopper quick access to HopperBrown to reflect the livery and not the type.