### PR TITLE
Port Plotter Improvements

### DIFF
--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -195,8 +195,6 @@ namespace CCL.Importer
                     }
                 }
 
-                AddTrainsets(carType);
-
                 CustomCarTypes.Add(carType);
                 CCLPlugin.Log($"Successfully loaded car type {car.id}");
             }
@@ -235,7 +233,7 @@ namespace CCL.Importer
             return true;
         }
 
-        private static void AddTrainsets(CCL_CarType car)
+        internal static void AddTrainsets(CCL_CarType car)
         {
             foreach(var livery in car.Variants)
             {

--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -2,6 +2,7 @@
 using CCL.Importer.Processing;
 using CCL.Importer.Types;
 using CCL.Types;
+using DV.ThingTypes;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -13,6 +14,7 @@ namespace CCL.Importer
     public static class CarManager
     {
         public static readonly List<CCL_CarType> CustomCarTypes = new();
+        public static readonly Dictionary<TrainCarLivery, TrainCarLivery[]> Trainsets = new();
 
         public static void ScanLoadedMods()
         {
@@ -193,6 +195,8 @@ namespace CCL.Importer
                     }
                 }
 
+                AddTrainsets(carType);
+
                 CustomCarTypes.Add(carType);
                 CCLPlugin.Log($"Successfully loaded car type {car.id}");
             }
@@ -229,6 +233,38 @@ namespace CCL.Importer
             var processor = new ModelProcessor(livery);
             processor.ExecuteSteps();
             return true;
+        }
+
+        private static void AddTrainsets(CCL_CarType car)
+        {
+            foreach(var livery in car.Variants)
+            {
+                // No trainset for single vehicles.
+                if (livery.TrainsetLiveries.Length < 2) continue;
+
+                List<TrainCarLivery> liveries = new();
+
+                foreach (var id in livery.TrainsetLiveries)
+                {
+                    if (DV.Globals.G.Types.TryGetLivery(id, out var match))
+                    {
+                        liveries.Add(match);
+                    }
+                    else
+                    {
+                        CCLPlugin.Error($"Could not find livery {id} for trainset of {livery.id}");
+                    }
+                }
+
+                Trainsets.Add(livery, liveries.ToArray());
+            }
+        }
+
+        public static TrainCarLivery[] GetTrainsetForLivery(TrainCarLivery car)
+        {
+            if (Trainsets.TryGetValue(car, out var set)) return set;
+
+            return Array.Empty<TrainCarLivery>();
         }
     }
 }

--- a/CCL.Importer/Extensions.cs
+++ b/CCL.Importer/Extensions.cs
@@ -14,11 +14,6 @@ namespace CCL.Importer
 {
     public static class Extensions
     {
-        public static bool IsEnvironmental(this ResourceType_v2 type)
-        {
-            return type.canDamageEnvironment;
-        }
-
         public static T GetOrAddComponent<T>(this GameObject go) where T : Component
         {
             if (go.TryGetComponent(out T comp))
@@ -99,12 +94,6 @@ namespace CCL.Importer
             return GetComponentInParentIncludingInactive<T>(component.gameObject);
         }
 
-        public static void RefreshChildren<T>(this ARefreshableChildrenController<T> controller)
-            where T : MonoBehaviour
-        {
-            controller.entries = controller.gameObject.GetComponentsInChildren<T>(true);
-        }
-
         public static bool EqualsOneOf<T>(this T compare, params T[] values)
         {
             foreach (T v in values)
@@ -165,28 +154,6 @@ namespace CCL.Importer
             return cacheValue.Value;
         }
 
-        public static void SetKeyAndUpdate(this Localize localize, string key)
-        {
-            localize.key = key;
-            localize.UpdateLocalization();
-        }
-
-        public static void ManualLocalize(this Localize localize, string key)
-        {
-            TMPHelper.GetTMP(localize).SetTextAndUpdate(LocalizationAPI.L(key));
-            UObject.DestroyImmediate(localize);
-        }
-
-        public static bool IsFrontCoupler(this TrainCar car, Coupler coupler)
-        {
-            return car.frontCoupler == coupler;
-        }
-
-        public static CoupleEventArgs CreateDummyArgs(this Coupler coupler)
-        {
-            return new CoupleEventArgs(coupler, coupler.coupledTo, false);
-        }
-
         //public static bool IsCustomCargoClass(this CargoContainerType containerType)
         //{
         //    return containerType == (CargoContainerType)BaseCargoContainerType.Custom;
@@ -221,6 +188,50 @@ namespace CCL.Importer
             else
             {
                 dest = default!;
+            }
+        }
+    }
+
+    public static class DVExtensions
+    {
+        public static bool IsEnvironmental(this ResourceType_v2 type)
+        {
+            return type.canDamageEnvironment;
+        }
+
+        public static void RefreshChildren<T>(this ARefreshableChildrenController<T> controller)
+            where T : MonoBehaviour
+        {
+            controller.entries = controller.gameObject.GetComponentsInChildren<T>(true);
+        }
+
+        public static void SetKeyAndUpdate(this Localize localize, string key)
+        {
+            localize.key = key;
+            localize.UpdateLocalization();
+        }
+
+        public static void ManualLocalize(this Localize localize, string key)
+        {
+            TMPHelper.GetTMP(localize).SetTextAndUpdate(LocalizationAPI.L(key));
+            UObject.DestroyImmediate(localize);
+        }
+
+        public static bool IsFrontCoupler(this TrainCar car, Coupler coupler)
+        {
+            return car.frontCoupler == coupler;
+        }
+
+        public static CoupleEventArgs CreateDummyArgs(this Coupler coupler)
+        {
+            return new CoupleEventArgs(coupler, coupler.coupledTo, false);
+        }
+
+        public static IEnumerable<TrainCar> AllLocos(this Trainset trainset)
+        {
+            foreach (var indice in trainset.locoIndices)
+            {
+                yield return trainset.cars[indice];
             }
         }
     }

--- a/CCL.Importer/Implementations/VirtualHandbrake.cs
+++ b/CCL.Importer/Implementations/VirtualHandbrake.cs
@@ -24,7 +24,7 @@ namespace CCL.Importer.Implementations
 
             if (coupler.coupledTo)
             {
-                OnCoupled(this, new CoupleEventArgs(coupler, coupler.coupledTo, false));
+                OnCoupled(this, coupler.CreateDummyArgs());
             }
         }
 

--- a/CCL.Importer/Patches/ObjectModelPatches.cs
+++ b/CCL.Importer/Patches/ObjectModelPatches.cs
@@ -27,4 +27,19 @@ namespace CCL.Importer.Patches
             return false;
         }
     }
+
+    [HarmonyPatch(typeof(DVObjectModel))]
+    internal class DVObjectModelPatches
+    {
+        [HarmonyPostfix,  HarmonyPatch(nameof(DVObjectModel.RecalculateCaches))]
+        private static void RecalculateCachesPostfix()
+        {
+            CarManager.Trainsets.Clear();
+
+            foreach (var car in CarManager.CustomCarTypes)
+            {
+                CarManager.AddTrainsets(car);
+            }
+        }
+    }
 }

--- a/CCL.Importer/Types/CCL_CarVariant.cs
+++ b/CCL.Importer/Types/CCL_CarVariant.cs
@@ -23,6 +23,7 @@ namespace CCL.Importer.Types
         public bool HideFrontCoupler;
         public bool HideBackCoupler;
 
+        public string[] TrainsetLiveries = new string[0];
         public LocoSpawnGroup[] LocoSpawnGroups = new LocoSpawnGroup[0];
         public CatalogPage? CatalogPage = null;
 

--- a/CCL.Types/Components/SimPortPlotter.cs
+++ b/CCL.Types/Components/SimPortPlotter.cs
@@ -9,10 +9,14 @@ namespace CCL.Types.Components
     public class SimPortPlotter : MonoBehaviour
     {
         public int TickRate = 5;
-        [PortId(null, null, false)]
+        [PortId]
         public List<string> PortIds = new List<string>();
         [PortReferenceId]
         public List<string> PortReferenceIds = new List<string>();
         public bool UseColours = true;
+        [Tooltip("Adds a dummy port that outputs the generated force of the vehicle")]
+        public bool AddDummyForcePort = true;
+        [Tooltip("Adds a dummy port that outputs the generated power of the vehicle")]
+        public bool AddDummyPowerPort = true;
     }
 }

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -44,7 +44,13 @@ namespace CCL.Types
         public bool HideFrontCoupler = false;
         public bool HideBackCoupler = false;
 
-        [Header("Spawning")]
+        [Header("Trainset - optional")]
+        [Tooltip("This is used to tell other mods if this vehicle is part of a set of vehicles\n" +
+            "Examples are a locomotive and her tender (S282A + S282B)\n" +
+            "Order is important")]
+        public string[] TrainsetLiveries = new string[0];
+
+        [Header("Spawning - optional")]
         public LocoSpawnGroup[] LocoSpawnGroups = new LocoSpawnGroup[0];
         [SerializeField, HideInInspector]
         private string? _spawnGroupJson = string.Empty;

--- a/CCL.Types/Extensions.cs
+++ b/CCL.Types/Extensions.cs
@@ -105,5 +105,11 @@ namespace CCL.Types
 
             return -1;
         }
+
+        // Swaps the values at the 2 indexes of the list.
+        public static void Swap<T>(this IList<T> list, int indexA, int indexB)
+        {
+            (list[indexB], list[indexA]) = (list[indexA], list[indexB]);
+        }
     }
 }


### PR DESCRIPTION
Added utility functions to SimPortPlotter.
* Dummy ports for generated force and power.
* Similar ports for the entire trainset.
* Quick port graph adder.

Improved visuals of SimPortPlotter.
* Draggable window.
* Organised buttons.
* Multiple window functionality.

Added Trainset field to liveries (closes #202).
* Allows specifying which other liveries are part of a set, so other mods can access this info (ex loco + tender).