### PR TITLE
Cargo Icons Temporary Fix/B99.5 Fix

### DIFF
--- a/CCL.Creator/Inspector/EnableIfAttributeEditor.cs
+++ b/CCL.Creator/Inspector/EnableIfAttributeEditor.cs
@@ -1,0 +1,70 @@
+﻿using CCL.Types;
+using System.Reflection;
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace CCL.Creator.Inspector
+{
+    [CustomPropertyDrawer(typeof(EnableIfAttribute), true)]
+    internal class EnableIfAttributeEditor : PropertyDrawer
+    {
+        private const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+        private MethodInfo? _method;
+        private FieldInfo? _field;
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            var att = (EnableIfAttribute)attribute;
+
+            if (_method == null && _field == null)
+            {
+                SetupMethodOrField(property.serializedObject.targetObject.GetType(), att.Target);
+
+                // If no target was found...
+                if (_method == null && _field == null)
+                {
+                    Debug.LogError($"Could not find field, property or target {att.Target} in {property.serializedObject.targetObject.GetType().Name}");
+                    base.OnGUI(position, property, label);
+                    return;
+                }
+            }
+
+            bool result = _method != null ?
+                (bool)_method.Invoke(property.serializedObject.targetObject, null) :
+                (bool)_field!.GetValue(property.serializedObject.targetObject);
+
+            EditorGUI.BeginProperty(position, label, property);
+            GUI.enabled = att.Invert ? !result : result;
+            EditorGUI.PropertyField(position, property, true);
+            GUI.enabled = true;
+            EditorGUI.EndProperty();
+            return;
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUI.GetPropertyHeight(property, label, true);
+        }
+
+        private void SetupMethodOrField(Type t, string target)
+        {
+            // Try to get a method, if it exists, leave.
+            _method = t.GetMethod(target, Flags);
+            if (_method != null) return;
+
+            // If no method exists, try for a property.
+            var p = t.GetProperty(target, Flags);
+
+            if (p != null)
+            {
+                _method = p.GetMethod;
+                if (_method != null) return;
+            }
+
+            // At last, try for a field.
+            _field = t.GetField(target, Flags);
+        }
+    }
+}

--- a/CCL.Creator/Inspector/VanillaHUDLayoutEditor.cs
+++ b/CCL.Creator/Inspector/VanillaHUDLayoutEditor.cs
@@ -28,9 +28,10 @@ namespace CCL.Creator.Inspector
 
             bool isCustom = _layout.HUDType == VanillaHUDLayout.BaseHUD.Custom;
 
-            GUI.enabled = isCustom;
-            EditorGUILayout.Foldout(isCustom, "Custom Layout Settings");
-            GUI.enabled = true;
+            using (new EditorGUI.DisabledScope(!isCustom))
+            {
+                EditorGUILayout.Foldout(isCustom, "Custom Layout Settings");
+            }
 
             if (!isCustom)
             {

--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -6,6 +6,7 @@ using DV.ThingTypes;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 using UnityModManagerNet;
 
@@ -140,6 +141,22 @@ namespace CCL.Importer
         {
             try
             {
+                // Ensure no duplicate IDs ever load, entire game dies otherwise.
+                if (DV.Globals.G.Types.carTypes.Any(x => x.id == car.id))
+                {
+                    CCLPlugin.Error($"Failed to load car {car.id}, car ID already ingame");
+                    return false;
+                }
+
+                foreach (var livery in car.liveries)
+                {
+                    if (DV.Globals.G.Types.Liveries.Any(x => x.id == livery.id))
+                    {
+                        CCLPlugin.Error($"Failed to load car {car.id}, livery ID '{livery.id}' already ingame");
+                        return false;
+                    }
+                }
+
                 car.AfterImport();
 
                 var carType = ScriptableObject.CreateInstance<CCL_CarType>();

--- a/CCL.Importer/CargoInjector.cs
+++ b/CCL.Importer/CargoInjector.cs
@@ -1,4 +1,5 @@
-﻿using CCL.Importer.Processing;
+﻿using CCL.Importer.Patches;
+using CCL.Importer.Processing;
 using CCL.Importer.Types;
 using CCL.Types;
 using DV;
@@ -46,7 +47,12 @@ namespace CCL.Importer
 
         public static Sprite GetCargoIcon(CargoType_v2 cargo, TrainCarType_v2 car)
         {
-            if (car is not CCL_CarType ccl) return cargo.icon;
+            if (car is not CCL_CarType ccl)
+            {
+                if (CargoType_v2Patches.OriginalSprites.TryGetValue(cargo, out var icon)) return icon;
+
+                return cargo.icon;
+            }
 
             // It should never be null if we get here, but it doesn't hurt to check.
             if (ccl.CargoSetup == null || !ccl.CargoSetup.Entries.TryFind(x => x.CargoId == cargo.id, out var entry)) return null!;

--- a/CCL.Importer/Implementations/DuplicateHandbrake.cs
+++ b/CCL.Importer/Implementations/DuplicateHandbrake.cs
@@ -1,4 +1,6 @@
 ﻿using CCL.Importer.Components;
+using DV.CabControls.Spec;
+using DV.Simulation.Brake;
 using DV.Simulation.Controllers;
 using DV.ThingTypes;
 
@@ -13,7 +15,7 @@ namespace CCL.Importer.Implementations
 
         public override float Value => _coupled != null ? _coupled.brakeSystem.handbrakePosition : base.Value;
 
-        public DuplicateHandbrake(TrainCar car, DuplicateHandbrakeOverriderInternal overrider) : base(car)
+        public DuplicateHandbrake(TrainCar car, DuplicateHandbrakeOverriderInternal overrider) : base(car, null)
         {
             _overrider = overrider;
 

--- a/CCL.Importer/Implementations/VirtualHandbrake.cs
+++ b/CCL.Importer/Implementations/VirtualHandbrake.cs
@@ -13,7 +13,7 @@ namespace CCL.Importer.Implementations
 
         protected override bool canExistWithoutHandbrake => true;
 
-        public VirtualHandbrake(TrainCar car, VirtualHandbrakeOverriderInternal overrider) : base(car)
+        public VirtualHandbrake(TrainCar car, VirtualHandbrakeOverriderInternal overrider) : base(car, null)
         {
             _overrider = overrider;
 

--- a/CCL.Importer/Patches/CargoIconTempPatches.cs
+++ b/CCL.Importer/Patches/CargoIconTempPatches.cs
@@ -1,0 +1,39 @@
+﻿using DV.RenderTextureSystem.BookletRender;
+using DV.UI.PresetEditors;
+using HarmonyLib;
+
+namespace CCL.Importer.Patches
+{
+    internal static class CargoIconTempPatches
+    {
+        [HarmonyPatch(typeof(TaskTemplatePaper))]
+        internal static class TaskTemplatePaperPatches
+        {
+            [HarmonyPostfix, HarmonyPatch(nameof(TaskTemplatePaper.FillInData))]
+            private static void FillInDataPostfix()
+            {
+                CargoType_v2Patches.ResetAll();
+            }
+        }
+
+        [HarmonyPatch(typeof(FrontPageTemplatePaper))]
+        internal static class FrontPageTemplatePaperPatches
+        {
+            [HarmonyPostfix, HarmonyPatch(nameof(FrontPageTemplatePaper.FillInData))]
+            private static void FillInDataPostfix()
+            {
+                CargoType_v2Patches.ResetAll();
+            }
+        }
+
+        [HarmonyPatch(typeof(TrainEditorViewElement))]
+        internal static class TrainEditorViewElementPatches
+        {
+            [HarmonyPostfix, HarmonyPatch("UpdateView")]
+            private static void UpdateViewPostfix()
+            {
+                CargoType_v2Patches.ResetAll();
+            }
+        }
+    }
+}

--- a/CCL.Importer/Patches/CargoType_v2Patches.cs
+++ b/CCL.Importer/Patches/CargoType_v2Patches.cs
@@ -1,0 +1,33 @@
+﻿using DV.ThingTypes;
+using HarmonyLib;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Importer.Patches
+{
+    [HarmonyPatch(typeof(CargoType_v2))]
+    internal class CargoType_v2Patches
+    {
+        public static readonly Dictionary<CargoType_v2, Sprite> OriginalSprites = new();
+
+        [HarmonyPostfix, HarmonyPatch(nameof(CargoType_v2.HasVisibleModelForCarType))]
+        private static void HasVisibleModelForCarTypePostfix(CargoType_v2 __instance, TrainCarType_v2 carType)
+        {
+            // Store the original sprite for reset purposes.
+            if (!OriginalSprites.ContainsKey(__instance))
+            {
+                OriginalSprites.Add(__instance, __instance.icon);
+            }
+
+            __instance.icon = CargoInjector.GetCargoIcon(__instance, carType);
+        }
+
+        public static void ResetAll()
+        {
+            foreach (var item in OriginalSprites)
+            {
+                item.Key.icon = item.Value;
+            }
+        }
+    }
+}

--- a/CCL.Importer/Processing/ExternalInteractableProcessor.cs
+++ b/CCL.Importer/Processing/ExternalInteractableProcessor.cs
@@ -141,7 +141,6 @@ namespace CCL.Importer.Processing
             }
 
             interactables.SetLayersRecursive(ModelProcessor.NonStandardLayerExclusion, DVLayer.Interactable);
-            FixControlColliders(interactables);
             SetupOpenables(interactables);
         }
 
@@ -163,15 +162,6 @@ namespace CCL.Importer.Processing
                         Replace(prefab.transform, current, _be2ChargePort);
                         break;
                 }
-            }
-        }
-
-        private static void FixControlColliders(GameObject root)
-        {
-            var controls = root.GetComponentsInChildren<Collider>(true);
-            foreach (var control in controls)
-            {
-                control.isTrigger = true;
             }
         }
 

--- a/CCL.Types/Components/Simulation/SteamMechanicalStokerDefinition.cs
+++ b/CCL.Types/Components/Simulation/SteamMechanicalStokerDefinition.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace CCL.Types.Components.Simulation
 {
-    public class SteamMechanicalStokerDefinition : SimComponentDefinitionProxy
+    public class SteamMechanicalStokerDefinition : SimComponentDefinitionProxy, IRecommendedDebugPorts
     {
         [Min(0.0f)]
         public float MaxTransferRate = 10f;
@@ -32,6 +32,11 @@ namespace CCL.Types.Components.Simulation
             new PortReferenceDefinition(DVPortValueType.CONTROL, "FIREBOX_COAL_CONTROL", true),
             new PortReferenceDefinition(DVPortValueType.COAL, "COAL_AMOUNT", false),
             new PortReferenceDefinition(DVPortValueType.COAL, "COAL_CONSUMPTION", true)
+        };
+
+        public IEnumerable<string> GetDebugPorts() => new[]
+        {
+            "STOKING_NORMALIZED"
         };
     }
 }

--- a/CCL.Types/CustomCarType.cs
+++ b/CCL.Types/CustomCarType.cs
@@ -6,6 +6,8 @@ using CCL.Types.Json;
 using CCL.Types.HUD;
 using CCL.Types.Proxies;
 
+using static CCL.Types.CustomCarType.BrakesSetup;
+
 namespace CCL.Types
 {
     [CreateAssetMenu(menuName = "CCL/Custom Car Type", order = MenuOrdering.CarType)]
@@ -205,8 +207,10 @@ namespace CCL.Types
 
             [Header("Performance Curves")]
             public BrakeCurveType TrainBrakeCurveType;
+            [EnableIf(nameof(EnableTrainBrakeCurve))]
             public AnimationCurve TrainBrakeCurve = null!;
             public BrakeCurveType IndBrakeCurveType;
+            [EnableIf(nameof(EnableIndBrakeCurve))]
             public AnimationCurve IndBrakeCurve = null!;
 
             public float ForcePerBogie => brakingForcePerBogieMultiplier * BOGIE_BRAKING_FORCE;
@@ -251,5 +255,9 @@ namespace CCL.Types
                 mechanicalPowertrainPrice = 0.0f;
             }
         }
+
+        // For the EnableIfAttribute to work cannot be in the nested class.
+        private bool EnableTrainBrakeCurve => brakes.TrainBrakeCurveType == BrakeCurveType.Custom;
+        private bool EnableIndBrakeCurve => brakes.IndBrakeCurveType == BrakeCurveType.Custom;
     }
 }

--- a/CCL.Types/EnableIfAttribute.cs
+++ b/CCL.Types/EnableIfAttribute.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+namespace CCL.Types
+{
+    public class EnableIfAttribute : PropertyAttribute
+    {
+        public string Target { get; }
+        public bool Invert { get; set; }
+
+        /// <summary>
+        /// Enables or disables the property in the inspector based on a condition.
+        /// </summary>
+        /// <param name="target">The name of the field, property, or method that decides when to enable/disable. Must be/return a bool.</param>
+        /// <param name="invert">If true, the result of <paramref name="target"/> will have the opposite effect.</param>
+        public EnableIfAttribute(string target, bool invert = false)
+        {
+            Target = target;
+            Invert = invert;
+        }
+    }
+}

--- a/CCL.Types/Proxies/Simulation/Diesel/DieselEngineDirectDefinitionProxy.cs
+++ b/CCL.Types/Proxies/Simulation/Diesel/DieselEngineDirectDefinitionProxy.cs
@@ -104,8 +104,8 @@ namespace CCL.Types.Proxies.Simulation.Diesel
 
             rpmToPowerCurve = new AnimationCurve()
             {
-                preWrapMode = WrapMode.Loop,
-                postWrapMode = WrapMode.Loop,
+                preWrapMode = WrapMode.ClampForever,
+                postWrapMode = WrapMode.ClampForever,
                 keys = new[]
                 {
                     new Keyframe
@@ -168,8 +168,8 @@ namespace CCL.Types.Proxies.Simulation.Diesel
 
             rpmToPowerCurve = new AnimationCurve()
             {
-                preWrapMode = WrapMode.Loop,
-                postWrapMode = WrapMode.Loop,
+                preWrapMode = WrapMode.ClampForever,
+                postWrapMode = WrapMode.ClampForever,
                 keys = new[]
                 {
                     new Keyframe
@@ -232,8 +232,8 @@ namespace CCL.Types.Proxies.Simulation.Diesel
 
             rpmToPowerCurve = new AnimationCurve()
             {
-                preWrapMode = WrapMode.Loop,
-                postWrapMode = WrapMode.Loop,
+                preWrapMode = WrapMode.ClampForever,
+                postWrapMode = WrapMode.ClampForever,
                 keys = new[]
                 {
                     new Keyframe

--- a/CCL.Types/Proxies/Weather/WindowProxy.cs
+++ b/CCL.Types/Proxies/Weather/WindowProxy.cs
@@ -14,12 +14,12 @@ namespace CCL.Types.Proxies.Weather
         public bool useBakedUVs;
         public bool mirrorX;
         public bool mirrorY;
-        public RenderTexture dropletRenderingTexture;
-        public Rigidbody rb;
+        public RenderTexture dropletRenderingTexture = null!;
+        public Rigidbody rb = null!;
 
-        [RenderMethodButtons]
-        [MethodButton(nameof(SetupDuplicates), "Setup duplicates")]
-        public bool buttonRender;
+        [RenderMethodButtons, SerializeField]
+        [MethodButton(nameof(SetupDuplicates), "Setup Duplicates")]
+        private bool _buttonRender;
 
         private void OnDrawGizmosSelected()
         {
@@ -50,12 +50,12 @@ namespace CCL.Types.Proxies.Weather
                 new Vector3(sizeInMeters.x, sizeInMeters.y, 0.1f));
         }
 
-        private static void SetupDuplicates(WindowProxy proxy)
+        private void SetupDuplicates()
         {
-            proxy.duplicates = proxy.transform.parent.GetComponentsInChildren<WindowProxy>().Where(x => x != proxy).ToArray();
-            proxy.simulate = true;
+            duplicates = transform.parent.GetComponentsInChildren<WindowProxy>().Where(x => x != this).ToArray();
+            simulate = true;
 
-            foreach (var window in proxy.duplicates)
+            foreach (var window in duplicates)
             {
                 window.simulate = false;
                 window.duplicates = new WindowProxy[0];


### PR DESCRIPTION
Added a *temporary* fix to allow custom cargo icons.
Added ID check to prevent duplicate car/livery IDs.
Added EnableIfAttribute.

Removed processing to turn external interactables colliders into triggers.

Changed all diesel engine curves wrap mode to clamp.

Fixed handbrake components to B99.5.