### PR TITLE
Physics Materials

### DIFF
--- a/CCL.Importer/Implementations/DuplicateHandbrake.cs
+++ b/CCL.Importer/Implementations/DuplicateHandbrake.cs
@@ -1,6 +1,4 @@
 ﻿using CCL.Importer.Components;
-using DV.CabControls.Spec;
-using DV.Simulation.Brake;
 using DV.Simulation.Controllers;
 using DV.ThingTypes;
 

--- a/CCL.Importer/Processing/MiscProcessor.cs
+++ b/CCL.Importer/Processing/MiscProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using CCL.Importer.Components;
 using CCL.Types.Components;
 using System.ComponentModel.Composition;
+using UnityEngine;
 
 namespace CCL.Importer.Processing
 {
@@ -13,6 +14,38 @@ namespace CCL.Importer.Processing
             //{
             //    TiltingInternal.Create(tilting);
             //}
+
+            foreach (var prefab in context.Car.AllPrefabs)
+            {
+                ProcessSetPhysicsMaterial(prefab);
+            }
+        }
+
+        private static PhysicMaterial? s_asphalt;
+        private static PhysicMaterial? s_ballast;
+        private static PhysicMaterial? s_liquid;
+        private static PhysicMaterial Asphalt => Extensions.GetCached(ref s_asphalt, () => null!);
+        private static PhysicMaterial Ballast => Extensions.GetCached(ref s_ballast, () =>
+            QuickAccess.Locomotives.S282B.externalInteractablesPrefab.transform.Find(
+                "Coal&Water/I_TenderCoal/coal1/coal1_walkable_collider/coal_full_walkable")
+            .GetComponent<BoxCollider>().sharedMaterial);
+        private static PhysicMaterial Liquid => Extensions.GetCached(ref s_liquid, () => null!);
+
+        private static void ProcessSetPhysicsMaterial(GameObject prefab)
+        {
+            foreach (var comp in prefab.GetComponentsInChildren<SetPhysicsMaterial>(true))
+            {
+                foreach (var collider in comp.Colliders)
+                {
+                    collider.sharedMaterial = comp.Material switch
+                    {
+                        //SetPhysicsMaterial.PhysicsMaterial.Asphalt => Asphalt,
+                        SetPhysicsMaterial.PhysicsMaterial.Ballast => Ballast,
+                        //SetPhysicsMaterial.PhysicsMaterial.Liquid => Liquid,
+                        _ => null!
+                    };
+                }
+            }
         }
     }
 }

--- a/CCL.Types/Components/SetPhysicsMaterial.cs
+++ b/CCL.Types/Components/SetPhysicsMaterial.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types.Components
+{
+    public class SetPhysicsMaterial : MonoBehaviour
+    {
+        public enum PhysicsMaterial
+        {
+            //Asphalt     = 0,
+            Ballast     = 1,
+            //Liquid      = 2
+        }
+
+        public PhysicsMaterial Material = PhysicsMaterial.Ballast;
+        public List<Collider> Colliders = new List<Collider>();
+
+        [RenderMethodButtons, SerializeField]
+        [MethodButton(nameof(AddChildren), "Add Child Colliders")]
+        private bool _buttons;
+
+        private void AddChildren()
+        {
+            foreach (var child in GetComponentsInChildren<Collider>(true))
+            {
+                if (!Colliders.Contains(child))
+                {
+                    Colliders.Add(child);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added SetPhysicsMaterial.
* Allows setting the physics material of colliders. Required for specific footstep sounds.

Added validation for fall safeties.

*As a note, could not find references to the other materials, so only 1 is available ATM (used for tender coal).*