### PR TITLE
Minimum version bump (V3.1.0) and fixes

### DIFF
--- a/CCL.Creator/Inspector/MeshGrabberColliderEditor.cs
+++ b/CCL.Creator/Inspector/MeshGrabberColliderEditor.cs
@@ -5,24 +5,24 @@ using UnityEngine;
 
 namespace CCL.Creator.Inspector
 {
-    [CustomEditor(typeof(MeshGrabberFilter))]
-    internal class MeshGrabberFilterEditor : Editor
+    [CustomEditor(typeof(MeshGrabberCollider))]
+    internal class MeshGrabberColliderEditor : Editor
     {
-        private MeshGrabberFilter _grabber = null!;
-        private SerializedProperty _filter = null!;
+        private MeshGrabberCollider _grabber = null!;
+        private SerializedProperty _collider = null!;
         private SerializedProperty _name = null!;
 
         private void OnEnable()
         {
-            _filter = serializedObject.FindProperty(nameof(MeshGrabberFilter.Filter));
-            _name = serializedObject.FindProperty(nameof(MeshGrabberFilter.ReplacementName));
+            _collider = serializedObject.FindProperty(nameof(MeshGrabberCollider.Collider));
+            _name = serializedObject.FindProperty(nameof(MeshGrabberCollider.ReplacementName));
         }
 
         public override void OnInspectorGUI()
         {
-            _grabber = (MeshGrabberFilter)target;
+            _grabber = (MeshGrabberCollider)target;
 
-            EditorGUILayout.PropertyField(_filter);
+            EditorGUILayout.PropertyField(_collider);
             EditorHelpers.StringWithSearchField(_name, MeshGrabber.MeshNames, EditorGUIUtility.singleLineHeight * 4, 40);
 
             serializedObject.ApplyModifiedProperties();
@@ -33,7 +33,7 @@ namespace CCL.Creator.Inspector
                 EditorGUILayout.HelpBox($"Name '{_name.stringValue}' does not exist!", MessageType.Error);
             }
 
-            if (GUILayout.Button("Pick Filter In Object"))
+            if (GUILayout.Button("Pick Collider In Object"))
             {
                 _grabber.PickSame();
                 AssetHelper.SaveAsset(_grabber);
@@ -46,14 +46,14 @@ namespace CCL.Creator.Inspector
                 AssetHelper.SaveAsset(_grabber);
             }
 
-            // Remove the mesh in the filter if it will be replaced anyways.
-            using (new EditorGUI.DisabledScope(!_grabber.Filter))
+            // Remove the mesh in the collider if it will be replaced anyways.
+            using (new EditorGUI.DisabledScope(!_grabber.Collider))
             {
-                if (GUILayout.Button("Set Mesh In Filter To None"))
+                if (GUILayout.Button("Set Mesh In Collider To None"))
                 {
-                    if (_grabber.Filter != null)
+                    if (_grabber.Collider != null)
                     {
-                        _grabber.Filter.mesh = null;
+                        _grabber.Collider.sharedMesh = null;
                         AssetHelper.SaveAsset(_grabber);
                     }
                 }

--- a/CCL.Creator/Inspector/ParticleDrawer.cs
+++ b/CCL.Creator/Inspector/ParticleDrawer.cs
@@ -20,8 +20,6 @@ namespace CCL.Creator.Inspector
                 case VanillaParticleSystem.SteamerEmberSparks:
                     Gizmos.DrawLine(Vector3.zero, Vector3.up);
                     break;
-                    Gizmos.DrawLine(Vector3.zero, Vector3.down);
-                    break;
                 default:
                     Gizmos.DrawLine(Vector3.zero, Vector3.forward);
                     break;

--- a/CCL.Creator/Validators/ColliderValidator.cs
+++ b/CCL.Creator/Validators/ColliderValidator.cs
@@ -41,7 +41,7 @@ namespace CCL.Creator.Validators
                 !collisionComp.Any(x => x.GetComponent<ServiceCollider>()))
             {
                 result.Warning($"{livery.id} - No collider with the {nameof(ServiceCollider)} component found, " +
-                    $"all colliders will be set to serviceable", collidersRoot);
+                    $"vehicle cannot be serviced!", collidersRoot);
             }
             if (collision != null && collision.transform.localPosition != Vector3.zero)
             {

--- a/CCL.Creator/Validators/ColliderValidator.cs
+++ b/CCL.Creator/Validators/ColliderValidator.cs
@@ -41,7 +41,7 @@ namespace CCL.Creator.Validators
                 !collisionComp.Any(x => x.GetComponent<ServiceCollider>()))
             {
                 result.Warning($"{livery.id} - No collider with the {nameof(ServiceCollider)} component found, " +
-                    $"it won't be possible to service this vehicle", collidersRoot);
+                    $"all colliders will be set to serviceable", collidersRoot);
             }
             if (collision != null && collision.transform.localPosition != Vector3.zero)
             {

--- a/CCL.Creator/Validators/ColliderValidator.cs
+++ b/CCL.Creator/Validators/ColliderValidator.cs
@@ -1,4 +1,5 @@
 ﻿using CCL.Types;
+using CCL.Types.Components;
 using CCL.Types.Proxies;
 using System;
 using System.Linq;
@@ -9,8 +10,6 @@ namespace CCL.Creator.Validators
     [RequiresStep(typeof(LiverySettingsValidator))]
     internal class ColliderValidator : LiveryValidator
     {
-        private const string ServiceTag = "MainTriggerCollider";
-
         public override string TestName => "Colliders";
 
         protected override ValidationResult ValidateLivery(CustomCarVariant livery)
@@ -38,10 +37,10 @@ namespace CCL.Creator.Validators
             }
             // For anything that isn't a generic car, check if it can be serviced.
             if (collisionComp.Length > 0 && livery.parentType != null &&
-                livery.parentType.KindSelection != DVTrainCarKind.Car && 
-                !collisionComp.Any(x => x.tag == ServiceTag))
+                livery.parentType.KindSelection != DVTrainCarKind.Car &&
+                !collisionComp.Any(x => x.GetComponent<ServiceCollider>()))
             {
-                result.Warning($"{livery.id} - No collider in {CarPartNames.Colliders.COLLISION} with the tag \"{ServiceTag}\" found, " +
+                result.Warning($"{livery.id} - No collider with the {nameof(ServiceCollider)} component found, " +
                     $"it won't be possible to service this vehicle", collidersRoot);
             }
             if (collision != null && collision.transform.localPosition != Vector3.zero)

--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -25,8 +25,6 @@ namespace CCL.Importer
         internal static readonly Dictionary<string, int> CurrentMapping = new();
         internal static readonly HashSet<TrainCarType> AddedValues = new();
 
-        internal static Version? ProcessingVersion;
-
         private static int s_tempId = IdMappingStart;
 
         public static void ScanLoadedMods()
@@ -97,8 +95,6 @@ namespace CCL.Importer
                 return 0;
             }
 
-            ProcessingVersion = version;
-
             pack.AfterImport();
 
             // Generate procedural materials.
@@ -135,8 +131,6 @@ namespace CCL.Importer
             }
 
             InjectTranslations(pack);
-
-            ProcessingVersion = null;
 
             return loaded;
         }

--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -72,7 +72,7 @@ namespace CCL.Importer
             if (loaded > 0)
             {
                 CCLPlugin.LogVerbose($"Loaded {loaded} cars from {mod.Path}");
-                DV.Globals.G.Types.RecalculateCaches();
+                Globals.G.Types.RecalculateCaches();
             }
         }
 

--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -25,6 +25,8 @@ namespace CCL.Importer
         internal static readonly Dictionary<string, int> CurrentMapping = new();
         internal static readonly HashSet<TrainCarType> AddedValues = new();
 
+        internal static Version? ProcessingVersion;
+
         private static int s_tempId = IdMappingStart;
 
         public static void ScanLoadedMods()
@@ -95,6 +97,8 @@ namespace CCL.Importer
                 return 0;
             }
 
+            ProcessingVersion = version;
+
             pack.AfterImport();
 
             // Generate procedural materials.
@@ -131,6 +135,8 @@ namespace CCL.Importer
             }
 
             InjectTranslations(pack);
+
+            ProcessingVersion = null;
 
             return loaded;
         }

--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -159,7 +159,7 @@ namespace CCL.Importer
             try
             {
                 // Ensure no duplicate IDs ever load, entire game dies otherwise.
-                if (DV.Globals.G.Types.carTypes.Any(x => x.id == car.id))
+                if (Globals.G.Types.carTypes.Any(x => x.id == car.id))
                 {
                     CCLPlugin.Error($"Failed to load car {car.id}, car ID already ingame");
                     return false;
@@ -167,7 +167,7 @@ namespace CCL.Importer
 
                 foreach (var livery in car.liveries)
                 {
-                    if (DV.Globals.G.Types.Liveries.Any(x => x.id == livery.id))
+                    if (Globals.G.Types.Liveries.Any(x => x.id == livery.id))
                     {
                         CCLPlugin.Error($"Failed to load car {car.id}, livery ID '{livery.id}' already ingame");
                         return false;
@@ -260,7 +260,7 @@ namespace CCL.Importer
         {
             if (!string.IsNullOrEmpty(car.GeneralLicense))
             {
-                if (DV.Globals.G.Types.TryGetGeneralLicense(car.GeneralLicense, out var license))
+                if (Globals.G.Types.TryGetGeneralLicense(car.GeneralLicense, out var license))
                 {
                     foreach (var item in carType.liveries)
                     {
@@ -277,7 +277,7 @@ namespace CCL.Importer
 
             foreach (var id in car.JobLicenses)
             {
-                if (DV.Globals.G.Types.TryGetJobLicense(id, out var license))
+                if (Globals.G.Types.TryGetJobLicense(id, out var license))
                 {
                     jobLicenses.Add(license);
                 }

--- a/CCL.Importer/CarTypeInjector.cs
+++ b/CCL.Importer/CarTypeInjector.cs
@@ -34,6 +34,9 @@ namespace CCL.Importer
                 {
                     livery.CatalogPage.AfterImport();
                     CatalogGenerator.PageInfos.Add(livery, livery.CatalogPage);
+
+                    CCLPlugin.Translations.AddTranslations(livery.CatalogPageNameTranslationKey, livery.CatalogPage.PageName);
+                    CCLPlugin.Translations.AddTranslations(livery.CatalogNicknameTranslationKey, livery.CatalogPage.Nickname);
                 }
             }
 

--- a/CCL.Importer/CatalogGenerator.cs
+++ b/CCL.Importer/CatalogGenerator.cs
@@ -75,18 +75,19 @@ namespace CCL.Importer
         private static void ProcessHeader(Transform page, CCL_CarVariant livery, CatalogPage layout)
         {
             Paths.GetImage(page, Paths.PageColor).color = layout.HeaderColour;
-            Paths.GetText(page, Paths.PageName).SetTextAndUpdate(layout.PageName);
+            Paths.GetText(page, Paths.PageName).gameObject.AddComponent<Localize>().SetKeyAndUpdate($"{CatalogPage.PageNameKeyPrefix}{livery.id}");
             Paths.GetText(page, Paths.Units).SetTextAndUpdate(layout.ConsistUnits);
 
-            if (string.IsNullOrEmpty(layout.Nickname))
+            var nick = Paths.GetLocalize(page, Paths.Nickname);
+
+            if (layout.HasNickname)
             {
-                page.Find(Paths.Nickname).gameObject.SetActive(false);
+                nick.SetKeyAndUpdate($"{CatalogPage.NicknameKeyPrefix}{livery.id}");
+                nick.gameObject.SetActive(true);
             }
             else
             {
-                var nick = Paths.GetText(page, Paths.Nickname);
-                nick.gameObject.SetActive(true);
-                nick.SetTextAndUpdate(layout.Nickname);
+                nick.gameObject.SetActive(false);
             }
 
             Paths.GetImage(page, Paths.Icon).sprite = livery.icon;

--- a/CCL.Importer/CatalogGenerator.cs
+++ b/CCL.Importer/CatalogGenerator.cs
@@ -75,14 +75,14 @@ namespace CCL.Importer
         private static void ProcessHeader(Transform page, CCL_CarVariant livery, CatalogPage layout)
         {
             Paths.GetImage(page, Paths.PageColor).color = layout.HeaderColour;
-            Paths.GetText(page, Paths.PageName).gameObject.AddComponent<Localize>().SetKeyAndUpdate($"{CatalogPage.PageNameKeyPrefix}{livery.id}");
+            Paths.GetText(page, Paths.PageName).gameObject.AddComponent<Localize>().SetKeyAndUpdate(livery.CatalogPageNameTranslationKey);
             Paths.GetText(page, Paths.Units).SetTextAndUpdate(layout.ConsistUnits);
 
             var nick = Paths.GetLocalize(page, Paths.Nickname);
 
             if (layout.HasNickname)
             {
-                nick.SetKeyAndUpdate($"{CatalogPage.NicknameKeyPrefix}{livery.id}");
+                nick.SetKeyAndUpdate(livery.CatalogNicknameTranslationKey);
                 nick.gameObject.SetActive(true);
             }
             else

--- a/CCL.Importer/Processing/ColliderProcessor.cs
+++ b/CCL.Importer/Processing/ColliderProcessor.cs
@@ -42,21 +42,6 @@ namespace CCL.Importer.Processing
                 collision.parent = colliderRoot.transform;
             }
 
-            // FOR OLDER VERSIONS ONLY
-            // REMOVE ONCE MINIMUM VERSION >= 3.0.3!!!
-            // Ensure PitStop detects this as a serviceable for anything not a default car.
-            if (CarManager.ProcessingVersion != null && CarManager.ProcessingVersion < new System.Version(3, 0, 0) &&
-                context.Car.parentType.kind.id != "Car")
-            {
-                if (collision.GetComponentsInChildren<ServiceCollider>().Length == 0)
-                {
-                    foreach (Transform item in collision.GetComponentsInChildren<Transform>())
-                    {
-                        item.tag = CarPartNames.Tags.MAIN_TRIGGER_COLLIDER;
-                    }
-                }
-            }
-
             // find [walkable]
             // copy walkable to items if items doesn't exist
             Transform walkable = colliderRoot.Find(CarPartNames.Colliders.WALKABLE);

--- a/CCL.Importer/Processing/ColliderProcessor.cs
+++ b/CCL.Importer/Processing/ColliderProcessor.cs
@@ -42,8 +42,11 @@ namespace CCL.Importer.Processing
                 collision.parent = colliderRoot.transform;
             }
 
+            // FOR OLDER VERSIONS ONLY
+            // REMOVE ONCE MINIMUM VERSION >= 3.0.3!!!
             // Ensure PitStop detects this as a serviceable for anything not a default car.
-            if (context.Car.parentType.kind.id != "Car")
+            if (CarManager.ProcessingVersion != null && CarManager.ProcessingVersion < new System.Version(3, 0, 0) &&
+                context.Car.parentType.kind.id != "Car")
             {
                 if (collision.GetComponentsInChildren<ServiceCollider>().Length == 0)
                 {

--- a/CCL.Importer/Processing/ColliderProcessor.cs
+++ b/CCL.Importer/Processing/ColliderProcessor.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.ComponentModel.Composition;
 using DV.ThingTypes;
 using DV.ThingTypes.TransitionHelpers;
+using CCL.Types.Components;
 
 namespace CCL.Importer.Processing
 {
@@ -27,7 +28,7 @@ namespace CCL.Importer.Processing
                 // collider should be initialized in prefab, but make sure
                 CCLPlugin.Warning("Adding collision root to car, should have been part of prefab!");
 
-                GameObject colliders = new GameObject(CarPartNames.Colliders.ROOT);
+                var colliders = new GameObject(CarPartNames.Colliders.ROOT);
                 colliderRoot = colliders.transform;
                 colliderRoot.parent = newFab.transform;
             }
@@ -41,10 +42,16 @@ namespace CCL.Importer.Processing
                 collision.parent = colliderRoot.transform;
             }
 
-            // Ensure PitStop detects this as a serviceable car
-            foreach (Transform item in collision.GetComponentsInChildren<Transform>())
+            // Ensure PitStop detects this as a serviceable for anything not a default car.
+            if (context.Car.parentType.kind.id != "Car")
             {
-                item.tag = CarPartNames.Tags.MAIN_TRIGGER_COLLIDER;
+                if (collision.GetComponentsInChildren<ServiceCollider>().Length == 0)
+                {
+                    foreach (Transform item in collision.GetComponentsInChildren<Transform>())
+                    {
+                        item.tag = CarPartNames.Tags.MAIN_TRIGGER_COLLIDER;
+                    }
+                }
             }
 
             // find [walkable]
@@ -89,7 +96,7 @@ namespace CCL.Importer.Processing
             {
                 CCLPlugin.LogVerbose("Adding bogie collider root");
 
-                GameObject bogiesRoot = new GameObject(CarPartNames.Colliders.BOGIES);
+                var bogiesRoot = new GameObject(CarPartNames.Colliders.BOGIES);
                 NewBogieColliderRoot = bogiesRoot.transform;
                 NewBogieColliderRoot.parent = colliderRoot.transform;
             }

--- a/CCL.Importer/Processing/GrabberProcessor.cs
+++ b/CCL.Importer/Processing/GrabberProcessor.cs
@@ -148,6 +148,7 @@ namespace CCL.Importer.Processing
 
             ProcessMaterialGrabberRenderer(prefab);
             ProcessMeshGrabberFilter(prefab);
+            ProcessMeshGrabberCollider(prefab);
             ProcessSoundGrabberSource(prefab);
         }
 
@@ -264,7 +265,31 @@ namespace CCL.Importer.Processing
                 }
                 else
                 {
-                    CCLPlugin.Error($"No filter in this MeshGrabberFilter ({grabber.name})!");
+                    CCLPlugin.Error($"No filter in this {nameof(MeshGrabberFilter)} ({grabber.name})!");
+                }
+
+                UnityEngine.Object.Destroy(grabber);
+            }
+        }
+
+        private static void ProcessMeshGrabberCollider(GameObject prefab)
+        {
+            foreach (var grabber in prefab.GetComponentsInChildren<MeshGrabberCollider>(true))
+            {
+                if (grabber.Collider != null)
+                {
+                    if (s_meshCache.Cache.TryGetValue(grabber.ReplacementName, out Mesh mesh))
+                    {
+                        grabber.Collider.sharedMesh = mesh;
+                    }
+                    else
+                    {
+                        CCLPlugin.Error($"Could not find cached key '{grabber.ReplacementName}'!");
+                    }
+                }
+                else
+                {
+                    CCLPlugin.Error($"No collider in this {nameof(MeshGrabberCollider)} ({grabber.name})!");
                 }
 
                 UnityEngine.Object.Destroy(grabber);

--- a/CCL.Importer/Proxies/MiscReplacer.cs
+++ b/CCL.Importer/Proxies/MiscReplacer.cs
@@ -114,7 +114,7 @@ namespace CCL.Importer.Proxies
 
         private void InvalidTeleportLocationReactionAfter(InvalidTeleportLocationReactionProxy src, InvalidTeleportLocationReaction dest)
         {
-            dest.gameObject.tag = "NO_TELEPORT";
+            dest.gameObject.tag = CarPartNames.Tags.NO_TELEPORT;
             dest.gameObject.SetLayer(DVLayer.Teleport_Destination);
 
             var instance = Object.Instantiate(dest, dest.transform.parent);

--- a/CCL.Importer/Types/CCL_CarVariant.cs
+++ b/CCL.Importer/Types/CCL_CarVariant.cs
@@ -10,7 +10,7 @@ namespace CCL.Importer.Types
 {
     public class CCL_CarVariant : TrainCarLivery
     {
-        public TranslationData NameTranslations = new TranslationData();
+        public TranslationData NameTranslations = new();
 
         public BogieType FrontBogie;
         public BogieType RearBogie;
@@ -33,6 +33,8 @@ namespace CCL.Importer.Types
         public bool UseCustomFrontBogie => FrontBogie == BogieType.Custom;
         public bool UseCustomRearBogie => RearBogie == BogieType.Custom;
         public bool UseCustomBuffers => BufferType == BufferType.Custom;
+        public string CatalogPageNameTranslationKey => $"ccl/vc/pagename/{id}";
+        public string CatalogNicknameTranslationKey => $"ccl/vc/nickname/{id}";
 
         public IEnumerable<GameObject> AllPrefabs
         {

--- a/CCL.Importer/WorkTrains/WorkTrainPurchaseHandler.cs
+++ b/CCL.Importer/WorkTrains/WorkTrainPurchaseHandler.cs
@@ -1,7 +1,6 @@
 ﻿using CCL.Importer.Types;
 using DV.Common;
 using DV.JObjectExtstensions;
-using DV.ThingTypes;
 using DV.UserManagement;
 using System;
 using System.Collections.Generic;

--- a/CCL.Importer/WorkTrains/WorkTrainPurchaseHandler.cs
+++ b/CCL.Importer/WorkTrains/WorkTrainPurchaseHandler.cs
@@ -1,6 +1,7 @@
 ﻿using CCL.Importer.Types;
 using DV.Common;
 using DV.JObjectExtstensions;
+using DV.ThingTypes;
 using DV.UserManagement;
 using System;
 using System.Collections.Generic;
@@ -58,6 +59,8 @@ namespace CCL.Importer.WorkTrains
 
         public static void Load(SaveGameData data)
         {
+            ResetGarageless();
+
             s_unlocked.Clear();
             s_ids.Clear();
             s_alreadySummoned.Clear();
@@ -116,6 +119,13 @@ namespace CCL.Importer.WorkTrains
             UserManager.Instance.CurrentUser.GameData.SetBool(SaveConstants.WORK_TRAIN_WARNING, true);
             UserManager.Instance.CurrentUser.Save(UserSavingMode.JustUser);
             PopupHelper.ShowOk(Localization.WorkTrains.WarningPopup);
+        }
+
+        private static void ResetGarageless()
+        {
+            var list = CarSpawner.Instance.vehiclesWithoutGarage.ToList();
+            list.RemoveAll(s_unlocked.Contains);
+            CarSpawner.Instance.vehiclesWithoutGarage = list.ToArray();
         }
     }
 }

--- a/CCL.Types/CarPartNames.cs
+++ b/CCL.Types/CarPartNames.cs
@@ -172,6 +172,7 @@
         {
             public const string LADDERS = "Ladders";
             public const string MAIN_TRIGGER_COLLIDER = "MainTriggerCollider";
+            public const string NO_TELEPORT = "NO_TELEPORT";
         }
     }
 }

--- a/CCL.Types/Catalog/CatalogPage.cs
+++ b/CCL.Types/Catalog/CatalogPage.cs
@@ -1,4 +1,5 @@
 ﻿using CCL.Types.Json;
+using DVLangHelper.Data;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -7,12 +8,16 @@ namespace CCL.Types.Catalog
     [CreateAssetMenu(menuName = "CCL/Vehicle Catalog Page", order = MenuOrdering.Catalog)]
     public class CatalogPage : ScriptableObject, ICustomSerialized
     {
+        public const string PageNameKeyPrefix = "ccl/vc/pagename/";
+        public const string NicknameKeyPrefix = "ccl/vc/nickname/";
+
         [Header("Header")]
         public Color HeaderColour = Color.yellow;
-        public string PageName = string.Empty;
+        public TranslationData PageName = new TranslationData();
         public string ConsistUnits = "1/1";
         [Tooltip("Optional")]
-        public string Nickname = string.Empty;
+        public bool HasNickname = false;
+        public TranslationData Nickname = new TranslationData();
         public string ProductionYears = "1900-1999";
 
         [Header("Vehicle Type")]

--- a/CCL.Types/Catalog/CatalogPage.cs
+++ b/CCL.Types/Catalog/CatalogPage.cs
@@ -8,9 +8,6 @@ namespace CCL.Types.Catalog
     [CreateAssetMenu(menuName = "CCL/Vehicle Catalog Page", order = MenuOrdering.Catalog)]
     public class CatalogPage : ScriptableObject, ICustomSerialized
     {
-        public const string PageNameKeyPrefix = "ccl/vc/pagename/";
-        public const string NicknameKeyPrefix = "ccl/vc/nickname/";
-
         [Header("Header")]
         public Color HeaderColour = Color.yellow;
         public TranslationData PageName = new TranslationData();
@@ -42,6 +39,10 @@ namespace CCL.Types.Catalog
         public HaulingScore Hauling = new HaulingScore();
         public ShuntingScore Shunting = new ShuntingScore();
 
+        [SerializeField, HideInInspector]
+        private string? _pageNameJson;
+        [SerializeField, HideInInspector]
+        private string? _nicknameJson;
         [SerializeField, HideInInspector]
         private string? _loadJson;
         [SerializeField, HideInInspector]
@@ -83,6 +84,9 @@ namespace CCL.Types.Catalog
 
         public void OnValidate()
         {
+            _pageNameJson = JSONObject.ToJson(PageName);
+            _nicknameJson = JSONObject.ToJson(Nickname);
+
             _loadJson = JSONObject.ToJson(LoadFlat);
             _loadInclineJson = JSONObject.ToJson(LoadIncline);
             _loadInclineWetJson = JSONObject.ToJson(LoadInclineWet);
@@ -99,6 +103,9 @@ namespace CCL.Types.Catalog
 
         public void AfterImport()
         {
+            PageName = JSONObject.FromJson(_pageNameJson, () => new TranslationData());
+            Nickname = JSONObject.FromJson(_nicknameJson, () => new TranslationData());
+
             LoadFlat = JSONObject.FromJson(_loadJson, () => new LoadRating());
             LoadIncline = JSONObject.FromJson(_loadInclineJson, () => new LoadRating());
             LoadInclineWet = JSONObject.FromJson(_loadInclineWetJson, () => new LoadRating());

--- a/CCL.Types/Components/MeshGrabberCollider.cs
+++ b/CCL.Types/Components/MeshGrabberCollider.cs
@@ -2,10 +2,10 @@
 
 namespace CCL.Types.Components
 {
-    [AddComponentMenu("CCL/Components/Grabbers/Mesh Grabber (Filter)")]
-    public class MeshGrabberFilter : MonoBehaviour
+    [AddComponentMenu("CCL/Components/Grabbers/Mesh Grabber (Collider)")]
+    public class MeshGrabberCollider : MonoBehaviour
     {
-        public MeshFilter Filter = null!;
+        public MeshCollider Collider = null!;
         public string ReplacementName = string.Empty;
 
         private void Reset()
@@ -15,7 +15,7 @@ namespace CCL.Types.Components
 
         public void PickSame()
         {
-            Filter = GetComponent<MeshFilter>();
+            Collider = GetComponent<MeshCollider>();
         }
     }
 }

--- a/CCL.Types/Components/ServiceCollider.cs
+++ b/CCL.Types/Components/ServiceCollider.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Components
+{
+    [AddComponentMenu("CCL/Components/Service Collider")]
+    [RequireComponent(typeof(Collider))]
+    public class ServiceCollider : MonoBehaviour
+    {
+        private void Start()
+        {
+            var col = GetComponent<Collider>();
+            col.isTrigger = true;
+            tag = CarPartNames.Tags.MAIN_TRIGGER_COLLIDER;
+
+            Destroy(this);
+        }
+    }
+}

--- a/CCL.Types/Components/ServiceCollider.cs
+++ b/CCL.Types/Components/ServiceCollider.cs
@@ -8,10 +8,7 @@ namespace CCL.Types.Components
     {
         private void Start()
         {
-            var col = GetComponent<Collider>();
-            col.isTrigger = true;
             tag = CarPartNames.Tags.MAIN_TRIGGER_COLLIDER;
-
             Destroy(this);
         }
     }

--- a/CCL.Types/Components/SoundGrabberSource.cs
+++ b/CCL.Types/Components/SoundGrabberSource.cs
@@ -8,6 +8,11 @@ namespace CCL.Types.Components
         public AudioSource Source = null!;
         public string ReplacementName = string.Empty;
 
+        private void Reset()
+        {
+            PickSame();
+        }
+
         public void PickSame()
         {
             Source = GetComponent<AudioSource>();

--- a/CCL.Types/ExporterConstants.cs
+++ b/CCL.Types/ExporterConstants.cs
@@ -5,7 +5,7 @@ namespace CCL.Types
     public static class ExporterConstants
     {
         public const string MOD_ID = "DVCustomCarLoader";
-        public static readonly Version ExporterVersion = new Version(3, 0, 0);
+        public static readonly Version ExporterVersion = new Version(3, 0, 3);
         public static readonly Version MinimumCompatibleVersion = new Version(3, 0, 0);
 
         public const string MOD_INFO_FILENAME = "Info.json";

--- a/CCL.Types/ExporterConstants.cs
+++ b/CCL.Types/ExporterConstants.cs
@@ -5,8 +5,8 @@ namespace CCL.Types
     public static class ExporterConstants
     {
         public const string MOD_ID = "DVCustomCarLoader";
-        public static readonly Version ExporterVersion = new Version(3, 0, 3);
-        public static readonly Version MinimumCompatibleVersion = new Version(3, 0, 0);
+        public static readonly Version ExporterVersion = new Version(3, 1, 0);
+        public static readonly Version MinimumCompatibleVersion = new Version(3, 1, 0);
 
         public const string MOD_INFO_FILENAME = "Info.json";
         public const string JSON_FILENAME = "car.json";

--- a/repository.json
+++ b/repository.json
@@ -2,6 +2,11 @@
   "Releases": [
     {
       "Id": "DVCustomCarLoader",
+      "Version": "3.1.0",
+      "DownloadUrl": "https://github.com/derail-valley-modding/custom-car-loader/releases/download/v3.1.0/DVCustomCarLoader.zip"
+    },
+    {
+      "Id": "DVCustomCarLoader",
       "Version": "3.0.2",
       "DownloadUrl": "https://github.com/derail-valley-modding/custom-car-loader/releases/download/v3.0.2/DVCustomCarLoader.zip"
     },


### PR DESCRIPTION
Due to having just a single released vehicle, it's easier to bump the minimum version and ensure everyone's in the same page.

Added MeshGrabberCollider.
Added ServiceCollider.

Changed catalog page name and nickname to be translateable.
Improved MeshGrabberFilter and SoundGrabberSource.

Fixed unlocked work trains persisting through saves (probably didn't actually happen, as the singleton should get destroyed when loading a new save).