### PR TITLE
3.1.9

### DIFF
--- a/CCL.Creator/CCLEditorSettings.cs
+++ b/CCL.Creator/CCLEditorSettings.cs
@@ -43,6 +43,8 @@ namespace CCL.Creator
         [Header("Editor Behaviour")]
         [Tooltip("Highlights GameObjects with specific names in the hierarchy window")]
         public bool HighlightSpecialGameObjectNames = true;
+        [Tooltip("Whether or not to include IDs from other mods in fields that support them (certain cargo packs, etc)")]
+        public bool IncludeIdsFromOtherMods = true;
 
         [Header("Port Display")]
         [Tooltip("Whether or not to display the port code on fields ([Port], [Fuse]...)")]

--- a/CCL.Creator/Inspector/Catalog/DiagramComponentDrawer.cs
+++ b/CCL.Creator/Inspector/Catalog/DiagramComponentDrawer.cs
@@ -138,5 +138,24 @@ namespace CCL.Creator.Inspector.Catalog
                 return color;
             }
         }
+
+        [DrawGizmo(GizmoType.InSelectionHierarchy | GizmoType.NotInSelectionHierarchy)]
+        private static void DrawGizmoVehicleBody(VehicleBody body, GizmoType gizmoType)
+        {
+            var t = (RectTransform)body.transform;
+            var centre = t.position;
+            var offsetV = new Vector3(0, t.sizeDelta.y / 2, 0);
+            var offsetH = new Vector3(t.sizeDelta.x / 2, 0, 0);
+
+            var points = new[]
+            {
+                centre + offsetV + offsetH,
+                centre + offsetV - offsetH,
+                centre - offsetV - offsetH,
+                centre - offsetV + offsetH
+            };
+
+            Handles.DrawSolidRectangleWithOutline(points, s_empty, Color.white);
+        }
     }
 }

--- a/CCL.Creator/Inspector/SimComponents/BatteryCustomCurveDefinitionEditor.cs
+++ b/CCL.Creator/Inspector/SimComponents/BatteryCustomCurveDefinitionEditor.cs
@@ -1,0 +1,34 @@
+﻿using CCL.Creator.Utility;
+using CCL.Types.Components.Simulation.Electric;
+using UnityEditor;
+
+namespace CCL.Creator.Inspector.SimComponents
+{
+    [CustomEditor(typeof(BatteryCustomCurveDefinition))]
+    internal class BatteryCustomCurveDefinitionEditor : Editor
+    {
+        private BatteryCustomCurveDefinition _proxy = null!;
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            _proxy = (BatteryCustomCurveDefinition)target;
+
+            float minVoltage = 0;
+            float maxVoltage = 0;
+
+            if (_proxy.chargeToVoltageCurve != null)
+            {
+                minVoltage = _proxy.numSeriesCells * _proxy.chargeToVoltageCurve[0].value;
+                maxVoltage = _proxy.numSeriesCells * _proxy.chargeToVoltageCurve[_proxy.chargeToVoltageCurve.length - 1].value;
+            }
+
+            EditorHelpers.DrawHeader("Calculated Values");
+            EditorGUILayout.LabelField("Min Voltage", $"{minVoltage:F2} V");
+            EditorGUILayout.LabelField("Max Voltage", $"{maxVoltage:F2} V");
+
+            EditorHelpers.DrawLocoDefaultsButtons(target);
+        }
+    }
+}

--- a/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
+++ b/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
@@ -126,6 +126,12 @@ namespace CCL.Creator.Inspector
         {
             // Add passengers as an extra custom option always.
             var options = new HashSet<string> { OtherMods.PassengerJobs.CARGO_ID };
+
+            if (CCLEditorSettings.Settings.IncludeIdsFromOtherMods)
+            {
+                options.UnionWith(OtherMods.CustomCargoIds);
+            }
+
             options.UnionWith(CCLEditorSettings.Settings.ExtraCargos);
             OnGUIWithExtraOptions(position, property, label, options);
         }

--- a/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
+++ b/CCL.Creator/Inspector/StringAndSelectorFieldAttributeEditor.cs
@@ -124,7 +124,10 @@ namespace CCL.Creator.Inspector
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            OnGUIWithExtraOptions(position, property, label, CCLEditorSettings.Settings.ExtraCargos);
+            // Add passengers as an extra custom option always.
+            var options = new HashSet<string> { OtherMods.PassengerJobs.CARGO_ID };
+            options.UnionWith(CCLEditorSettings.Settings.ExtraCargos);
+            OnGUIWithExtraOptions(position, property, label, options);
         }
     }
 

--- a/CCL.Creator/Utility/CarPrefabChecker.cs
+++ b/CCL.Creator/Utility/CarPrefabChecker.cs
@@ -6,8 +6,6 @@ namespace CCL.Creator.Utility
     [AddComponentMenu("CCL Editor/Car Prefab Checker")]
     internal class CarPrefabChecker : MonoBehaviour, IEditorComponent
     {
-        private const float HalfGauge = 1.435f / 2;
-
         private static readonly Color s_bogies = Color.Lerp(Color.green, Color.white, 0.35f);
         private static readonly Color s_couplers = Color.Lerp(Color.blue, Color.white, 0.35f);
         private static readonly Color s_com = Color.Lerp(Color.red, Color.white, 0.35f);
@@ -20,7 +18,8 @@ namespace CCL.Creator.Utility
         public Transform? CoM;
         public int Gauge = 1435;
 
-        private float ActualGauge => Gauge / 2000f;
+        private float HalfGauge => Gauge / 2000f;
+        private float ActualGauge => Gauge / 1000f;
 
         public void OnValidate()
         {
@@ -37,7 +36,7 @@ namespace CCL.Creator.Utility
         {
             Gizmos.color = Color.grey;
 
-            var gauge = ActualGauge;
+            var gauge = HalfGauge;
             var track1 = new Vector3(gauge, 0, -20);
             var track2 = new Vector3(gauge, 0, 20);
             var arrow1 = new Vector3(-gauge, 0, -1.5f);
@@ -57,11 +56,11 @@ namespace CCL.Creator.Utility
 
             if (BogieF != null)
             {
-                Gizmos.DrawLine(BogieF.position, BogieF.position + Vector3.up * 2);
+                DrawBogie(BogieF);
             }
             if (BogieR != null)
             {
-                Gizmos.DrawLine(BogieR.position, BogieR.position + Vector3.up * 2);
+                DrawBogie(BogieR);
             }
 
             Gizmos.color = s_couplers;
@@ -80,6 +79,23 @@ namespace CCL.Creator.Utility
             if (CoM != null)
             {
                 Gizmos.DrawWireSphere(CoM.position, 0.25f);
+            }
+        }
+
+        private void DrawBogie(Transform bogie)
+        {
+            Gizmos.DrawLine(bogie.position, bogie.position + Vector3.up * 2);
+
+            bogie = bogie.Find(CarPartNames.Bogies.BOGIE_CAR);
+
+            if (bogie == null) return;
+
+            foreach (Transform t in bogie)
+            {
+                if (t.name == CarPartNames.Bogies.AXLE)
+                {
+                    Gizmos.DrawLine(t.position - t.right * ActualGauge, t.position + t.right * ActualGauge);
+                }
             }
         }
     }

--- a/CCL.Creator/Utility/OtherMods.cs
+++ b/CCL.Creator/Utility/OtherMods.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using CCL.Types;
 
@@ -6,40 +7,65 @@ namespace CCL.Creator.Utility
 {
     internal static class OtherMods
     {
-        public class PassengerJobs
+        public static class PassengerJobs
         {
+            public const string MOD_ID = "PassengerJobs";
             public const string CARGO_ID = "Passengers";
             public const float CARGO_MASS = 3000;
         }
 
-        public const string PASSENGER_JOBS = "PassengerJobs";
+        public static class GenericContainerCargo
+        {
+            public const string MOD_ID = "CC_GenericContainerCargo";
+            public const string CHEMICALS_ID = "GenericChemicals";
+            public const string CLOTHING_ID = "GenericClothing";
+            public const string ELECTRONICS_ID = "GenericElectronics";
+            public const string TOOLING_ID = "GenericTools";
+            public const string EMPTY_ID = "EmptyContainers";
+            public const float CHEMICALS_MASS = 30000;
+            public const float CLOTHING_MASS = 31000;
+            public const float ELECTRONICS_MASS = 35000;
+            public const float TOOLING_MASS = 37000;
+            public const float EMPTY_MASS = 6000;
+
+            public static bool IsAnyId(string id)
+            {
+                switch (id)
+                {
+                    case CHEMICALS_ID:
+                    case CLOTHING_ID:
+                    case ELECTRONICS_ID:
+                    case EMPTY_ID:
+                    case TOOLING_ID:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+
         public const string CUSTOM_CARGO = "DVCustomCargo";
         public const string CUSTOM_LICENSES = "DVCustomLicenses";
         public const string GAUGE = "Gauge";
+
+        public static readonly string[] CustomCargoIds = new[]
+        {
+            GenericContainerCargo.EMPTY_ID,
+            GenericContainerCargo.CHEMICALS_ID,
+            GenericContainerCargo.CLOTHING_ID,
+            GenericContainerCargo.ELECTRONICS_ID,
+            GenericContainerCargo.TOOLING_ID,
+        };
 
         public static List<string> GetModRequirements(CustomCarPack pack)
         {
             var requirements = new List<string>() { ExporterConstants.MOD_ID };
 
-            if (pack.Cars.Any(x => RequiresPassengerJobsMod(x)))
-            {
-                requirements.Add(PASSENGER_JOBS);
-            }
-
-            if (pack.Cars.Any(x => RequiresCustomCargoMod(x)))
-            {
-                requirements.Add(CUSTOM_CARGO);
-            }
-
-            if (pack.Cars.Any(x => RequiresCustomLicenseMod(x)))
-            {
-                requirements.Add(CUSTOM_LICENSES);
-            }
-
-            if (pack.Cars.Any(x => RequiresGaugeMod(x)))
-            {
-                requirements.Add(GAUGE);
-            }
+            CheckRequires(RequiresPassengerJobsMod, PassengerJobs.MOD_ID);
+            CheckRequires(RequiresCustomCargoMod, CUSTOM_CARGO);
+            CheckRequires(RequiresGenericContainersMod, GenericContainerCargo.MOD_ID);
+            CheckRequires(RequiresCustomLicenseMod, CUSTOM_LICENSES);
+            CheckRequires(RequiresGaugeMod, GAUGE);
 
             foreach (var item in pack.AdditionalDependencies)
             {
@@ -49,6 +75,14 @@ namespace CCL.Creator.Utility
             }
 
             return requirements;
+
+            void CheckRequires(Func<CustomCarType, bool> check, string id)
+            {
+                if (pack.Cars.Any(check))
+                {
+                    requirements.Add(id);
+                }
+            }
         }
 
         public static bool RequiresPassengerJobsMod(CustomCarType carType)
@@ -59,6 +93,11 @@ namespace CCL.Creator.Utility
         public static bool RequiresCustomCargoMod(CustomCarType carType)
         {
             return carType.CargoSetup != null && carType.CargoSetup.Entries.Any(x => x.CargoId != PassengerJobs.CARGO_ID && !Utilities.IsVanillaCargo(x.CargoId));
+        }
+
+        public static bool RequiresGenericContainersMod(CustomCarType carType)
+        {
+            return carType.CargoSetup != null && carType.CargoSetup.Entries.Any(x => GenericContainerCargo.IsAnyId(x.CargoId));
         }
 
         public static bool RequiresCustomLicenseMod(CustomCarType carType)

--- a/CCL.Creator/Utility/OtherMods.cs
+++ b/CCL.Creator/Utility/OtherMods.cs
@@ -6,6 +6,12 @@ namespace CCL.Creator.Utility
 {
     internal static class OtherMods
     {
+        public class PassengerJobs
+        {
+            public const string CARGO_ID = "Passengers";
+            public const float CARGO_MASS = 3000;
+        }
+
         public const string PASSENGER_JOBS = "PassengerJobs";
         public const string CUSTOM_CARGO = "DVCustomCargo";
         public const string CUSTOM_LICENSES = "DVCustomLicenses";
@@ -47,12 +53,12 @@ namespace CCL.Creator.Utility
 
         public static bool RequiresPassengerJobsMod(CustomCarType carType)
         {
-            return carType.CargoSetup != null && carType.CargoSetup.Entries.Any(x => x.CargoId == "Passengers");
+            return carType.CargoSetup != null && carType.CargoSetup.Entries.Any(x => x.CargoId == PassengerJobs.CARGO_ID);
         }
 
         public static bool RequiresCustomCargoMod(CustomCarType carType)
         {
-            return carType.CargoSetup != null && carType.CargoSetup.Entries.Any(x => x.CargoId != "Passengers" && !Utilities.IsVanillaCargo(x.CargoId));
+            return carType.CargoSetup != null && carType.CargoSetup.Entries.Any(x => x.CargoId != PassengerJobs.CARGO_ID && !Utilities.IsVanillaCargo(x.CargoId));
         }
 
         public static bool RequiresCustomLicenseMod(CustomCarType carType)

--- a/CCL.Creator/Validators/BasicValidators.cs
+++ b/CCL.Creator/Validators/BasicValidators.cs
@@ -65,6 +65,30 @@ namespace CCL.Creator.Validators
                 result.Warning("Livery can spawn in the world but is also set as a work train, this can result in unintended behaviour", livery);
             }
 
+            // Demo stuff checks.
+            if (livery.UseCustomPartsModel)
+            {
+                if (livery.PartsCargoPrefabDM1U == null)
+                {
+                    result.Warning($"Livery '{livery.id}' is set to use custom demonstrator parts model, but has no prefab to load on the DM1U-150",
+                        livery, nameof(livery.PartsCargoPrefabDM1U));
+                }
+                else
+                {
+                    CargoValidator.CheckModelVariant(result, livery.PartsCargoPrefabDM1U);
+                }
+
+                if (livery.PartsCargoPrefabFlatbed == null)
+                {
+                    result.Warning($"Livery '{livery.id}' is set to use custom demonstrator parts model, but has no prefab to load on the Utility Flatbed",
+                        livery, nameof(livery.PartsCargoPrefabFlatbed));
+                }
+                else
+                {
+                    CargoValidator.CheckModelVariant(result, livery.PartsCargoPrefabFlatbed);
+                }
+            }
+
             return result;
         }
     }

--- a/CCL.Creator/Validators/BasicValidators.cs
+++ b/CCL.Creator/Validators/BasicValidators.cs
@@ -66,6 +66,19 @@ namespace CCL.Creator.Validators
             }
 
             // Demo stuff checks.
+            if (livery.DemonstratorPoster != null)
+            {
+                var poster = livery.DemonstratorPoster;
+                if (poster.height != poster.width)
+                {
+                    result.Fail($"Livery '{livery.id}' demonstrator poster is not a square texture");
+                }
+                else if (poster.height != 512 || poster.width != 512)
+                {
+                    result.Warning($"Livery '{livery.id}' demonstrator poster size should be 512x512px");
+                }
+            }
+
             if (livery.UseCustomPartsModel)
             {
                 if (livery.PartsCargoPrefabDM1U == null)

--- a/CCL.Creator/Validators/BasicValidators.cs
+++ b/CCL.Creator/Validators/BasicValidators.cs
@@ -24,6 +24,11 @@ namespace CCL.Creator.Validators
 
             var result = Pass();
 
+            if (livery.id.IndexOf(' ') > 0)
+            {
+                result.Warning("Livery ID should not contain spaces", livery);
+            }
+
             if (livery.icon == null)
             {
                 result.Warning($"Livery '{livery.id}' has no icon", livery, nameof(livery.icon));

--- a/CCL.Creator/Validators/CarPackValidator.cs
+++ b/CCL.Creator/Validators/CarPackValidator.cs
@@ -285,7 +285,7 @@ namespace CCL.Creator.Validators
 
             if (PlayerSettings.colorSpace != UnityEngine.ColorSpace.Linear)
             {
-                _settingsResult.Warning("Colour space is not set to linear");
+                _settingsResult.Fail("Colour space is not set to linear");
                 _settingsResult.AddSettingsContextToLast("Project/Player");
             }
 
@@ -294,25 +294,25 @@ namespace CCL.Creator.Validators
 
             if (!PlayerSettings.virtualRealitySupported)
             {
-                _settingsResult.Warning("VR support isn't enabled");
+                _settingsResult.Fail("VR support isn't enabled");
                 _settingsResult.AddSettingsContextToLast("Project/Player");
             }
 
             string[] sdks = PlayerSettings.GetVirtualRealitySDKs(BuildTargetGroup.Standalone);
             if (!sdks.Contains("Oculus"))
             {
-                _settingsResult.Warning("Oculus support isn't enabled");
+                _settingsResult.Fail("Oculus support isn't enabled");
                 _settingsResult.AddSettingsContextToLast("Project/Player");
             }
             if (!sdks.Contains("OpenVR"))
             {
-                _settingsResult.Warning("OpenVR support isn't enabled");
+                _settingsResult.Fail("OpenVR support isn't enabled");
                 _settingsResult.AddSettingsContextToLast("Project/Player");
             }
 
             if (!PlayerSettings.singlePassStereoRendering)
             {
-                _settingsResult.Warning("VR Stereo Rendering Mode isn't set to Single Pass");
+                _settingsResult.Fail("VR Stereo Rendering Mode isn't set to Single Pass");
                 _settingsResult.AddSettingsContextToLast("Project/Player");
             }
 

--- a/CCL.Creator/Validators/CarSettingsValidator.cs
+++ b/CCL.Creator/Validators/CarSettingsValidator.cs
@@ -28,6 +28,11 @@ namespace CCL.Creator.Validators
                 return result;
             }
 
+            if (car.id.IndexOf(' ') > 0)
+            {
+                result.Warning("Car ID should not contain spaces", car);
+            }
+
             if (car.KindSelection != DVTrainCarKind.Car)
             {
                 if (car.unusedCarDeletePreventionMode == CustomCarType.UnusedCarDeletePreventionMode.None)

--- a/CCL.Creator/Validators/CargoValidator.cs
+++ b/CCL.Creator/Validators/CargoValidator.cs
@@ -36,7 +36,7 @@ namespace CCL.Creator.Validators
                 {
                     if (hashId.Contains(cargo.CargoId))
                     {
-                        result.Warning($"Repeated instance of cargo '{cargo.CargoId}'");
+                        result.Fail($"Repeated instance of cargo '{cargo.CargoId}'");
                     }
                     else
                     {

--- a/CCL.Creator/Validators/CargoValidator.cs
+++ b/CCL.Creator/Validators/CargoValidator.cs
@@ -23,25 +23,24 @@ namespace CCL.Creator.Validators
             {
                 var cargo = car.CargoSetup.Entries[i];
 
-                if (cargo.AmountPerCar <= 0)
-                {
-                    result.Fail("Cannot have 0 or negative cargo amount per car");
-                }
-
                 if (string.IsNullOrWhiteSpace(cargo.CargoId))
                 {
-                    result.Fail("Cargo ID is empty");
+                    result.Fail("Cargo ID is empty", car.CargoSetup);
+                    continue;
+                }
+
+                if (cargo.AmountPerCar <= 0)
+                {
+                    result.Fail($"Cargo {cargo.CargoId} - Cannot have 0 or negative cargo amount per car", car.CargoSetup);
+                }
+
+                if (hashId.Contains(cargo.CargoId))
+                {
+                    result.Fail($"Repeated cargo ID '{cargo.CargoId}'", car.CargoSetup);
                 }
                 else
                 {
-                    if (hashId.Contains(cargo.CargoId))
-                    {
-                        result.Fail($"Repeated instance of cargo '{cargo.CargoId}'");
-                    }
-                    else
-                    {
-                        hashId.Add(cargo.CargoId);
-                    }
+                    hashId.Add(cargo.CargoId);
                 }
 
                 if (cargo.Models != null)

--- a/CCL.Creator/Validators/CargoValidator.cs
+++ b/CCL.Creator/Validators/CargoValidator.cs
@@ -1,5 +1,6 @@
 ﻿using CCL.Types;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace CCL.Creator.Validators
@@ -80,9 +81,17 @@ namespace CCL.Creator.Validators
             {
                 result.Warning($"Cargo {model.name} bounding {CarPartNames.Colliders.COLLISION} collider is missing", collidersRoot);
             }
-            else if (collision != null && InvalidOrigin(collision))
+            else if (collision != null)
             {
-                result.Warning($"Cargo {model.name} - {CarPartNames.Colliders.COLLISION} is not at the local origin", model);
+                if (InvalidOrigin(collision))
+                {
+                    result.Warning($"Cargo {model.name} - {CarPartNames.Colliders.COLLISION} is not at the local origin", model);
+                }
+
+                if (collision.GetComponentsInChildren<MeshCollider>().Any(x => !x.convex))
+                {
+                    result.Fail($"Cargo {model.name} - Non-convex mesh colliders are not supported for car collisions");
+                }
             }
 
             // Walkable collider.

--- a/CCL.Creator/Validators/CargoValidator.cs
+++ b/CCL.Creator/Validators/CargoValidator.cs
@@ -58,7 +58,7 @@ namespace CCL.Creator.Validators
             return result;
         }
 
-        private void CheckModelVariant(ValidationResult result, GameObject model)
+        public static void CheckModelVariant(ValidationResult result, GameObject model)
         {
             // Check colliders.
             var collidersRoot = model.transform.FindSafe(CarPartNames.Colliders.ROOT);

--- a/CCL.Creator/Validators/CatalogValidator.cs
+++ b/CCL.Creator/Validators/CatalogValidator.cs
@@ -1,0 +1,61 @@
+﻿using CCL.Creator.Utility;
+using CCL.Types;
+using CCL.Types.Catalog;
+using System.Linq;
+
+namespace CCL.Creator.Validators
+{
+    [RequiresStep(typeof(LiverySettingsValidator))]
+    internal class CatalogValidator : LiveryValidator
+    {
+        public override string TestName => "Catalog";
+
+        protected override ValidationResult ValidateLivery(CustomCarVariant livery)
+        {
+            var page = livery.CatalogPage;
+
+            if (page == null || livery.parentType == null) return Skip();
+
+            var result = Pass();
+            var cargo = livery.parentType.CargoSetup;
+
+            if (HasRole(page, VehicleRole.PassengerTransport))
+            {
+                if (cargo == null || !cargo.Entries.Any(x => x.CargoId == OtherMods.PassengerJobs.CARGO_ID))
+                {
+                    result.Warning("Catalog page has Passenger Transport role, yet vehicle does not have passenger cargo");
+                }
+            }
+
+            if (HasRole(page, VehicleRole.FreightTransport))
+            {
+                if (cargo == null || cargo.Entries.All(x => x.CargoId == OtherMods.PassengerJobs.CARGO_ID))
+                {
+                    result.Warning("Catalog page has Freight Transport role, yet vehicle does not have non-passenger cargo");
+                }
+            }
+
+            if (page.LoadFlat.Tonnage < page.LoadIncline.Tonnage)
+            {
+                result.Warning("Flat load rating is lower than 2% incline load rating");
+            }
+
+            if (page.LoadFlat.Tonnage < page.LoadInclineWet.Tonnage)
+            {
+                result.Warning("Flat load rating is lower than 2% wet incline load rating");
+            }
+
+            if (page.LoadIncline.Tonnage < page.LoadInclineWet.Tonnage)
+            {
+                result.Warning("2% incline load rating is lower than 2% wet incline load rating");
+            }
+
+            return result;
+        }
+
+        private static bool HasRole(CatalogPage page, VehicleRole role)
+        {
+            return page.Role1 == role || page.Role2 == role;
+        }
+    }
+}

--- a/CCL.Creator/Validators/ComponentValidator.cs
+++ b/CCL.Creator/Validators/ComponentValidator.cs
@@ -1,6 +1,8 @@
 ﻿using CCL.Creator.Utility;
 using CCL.Types;
 using CCL.Types.Proxies.Simulation.Steam;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace CCL.Creator.Validators
@@ -87,12 +89,53 @@ namespace CCL.Creator.Validators
                 result.Fail(AddCompToMessage(self, "editor-only component must be removed before exporting"), self);
             }
 
+            count += TestLODs(prefab, result);
+
             return count;
 
             static string AddCompToMessage(Component comp, string message)
             {
                 return $"{comp.name}/{comp.GetType().Name}: {message}";
             }
+        }
+
+        private static int TestLODs(GameObject prefab, ValidationResult result)
+        {
+            var dict = new Dictionary<LODGroup, HashSet<Renderer>>();
+            int count = 0;
+
+            foreach (var group in prefab.GetComponentsInChildren<LODGroup>(true))
+            {
+                var set = new HashSet<Renderer>();
+
+                foreach (var lod in group.GetLODs())
+                {
+                    set.UnionWith(lod.renderers);
+                }
+
+                foreach (var renderer in set)
+                {
+                    var groups = new HashSet<LODGroup> { group };
+
+                    foreach (var pair in dict)
+                    {
+                        if (pair.Value.Contains(renderer))
+                        {
+                            groups.Add(pair.Key);
+                        }
+                    }
+
+                    if (groups.Count > 1)
+                    {
+                        result.Fail($"Renderer {renderer.name} is in multiple LOD Groups: {string.Join(", ", groups.Select(x => x.name))}", renderer);
+                    }
+                }
+
+                dict.Add(group, set);
+                count++;
+            }
+
+            return count;
         }
 
         private static int TestLubricatorRatchet(CustomCarVariant livery, ValidationResult result)

--- a/CCL.Creator/Validators/ControlsValidator.cs
+++ b/CCL.Creator/Validators/ControlsValidator.cs
@@ -1,5 +1,6 @@
 ﻿using CCL.Types;
 using CCL.Types.Proxies.Controls;
+using CCL.Types.Proxies.Weather;
 using System.Linq;
 using UnityEngine;
 
@@ -130,6 +131,14 @@ namespace CCL.Creator.Validators
                         break;
                     default:
                         break;
+                }
+            }
+
+            foreach (var openable in prefab.GetComponentsInChildren<OpenableControlProxy>())
+            {
+                if (!ComponentUtil.HasComponent<ControlSpecProxy>(openable))
+                {
+                    result.Fail($"OpenableControl lacks control", openable);
                 }
             }
 

--- a/CCL.Creator/Validators/ControlsValidator.cs
+++ b/CCL.Creator/Validators/ControlsValidator.cs
@@ -1,7 +1,6 @@
 ﻿using CCL.Types;
 using CCL.Types.Proxies.Controls;
 using System.Linq;
-using System.Runtime.Remoting.Messaging;
 using UnityEngine;
 
 namespace CCL.Creator.Validators

--- a/CCL.Creator/Wizards/CalculatorWizard.cs
+++ b/CCL.Creator/Wizards/CalculatorWizard.cs
@@ -361,6 +361,10 @@ namespace CCL.Creator.Wizards
                         PoweredAxles = tms.numberOfTractionMotors;
                         break;
 
+                    case GameObject prefab:
+                        Guess(prefab.GetComponentInChildren<TractionMotorSetDefinitionProxy>());
+                        break;
+
                     default:
                         break;
                 }
@@ -392,7 +396,6 @@ namespace CCL.Creator.Wizards
                     EditorGUILayout.HelpBox("Please link your current traction motor configuration in the field above", MessageType.Info);
                     return;
                 }
-
 
                 for (int i = 0; i < Definition.configurations.Length; i++)
                 {

--- a/CCL.Creator/Wizards/CarWizard.cs
+++ b/CCL.Creator/Wizards/CarWizard.cs
@@ -107,7 +107,8 @@ namespace CCL.Creator.Wizards
                 "Car Name", _carSettings.Name);
 
             _carSettings.ID = RenderTextbox(
-                "This will be the unique identifier for your car - we will also apply it to the default livery",
+                "This will be the unique identifier for your car - we will also apply it to the default livery\n" +
+                "Avoid spaces in ID fields",
                 "Car ID", _carSettings.ID);
 
             _carSettings.Kind = RenderEnum(
@@ -122,7 +123,7 @@ namespace CCL.Creator.Wizards
             {
                 _carSettings.Role = RenderEnum(
                     "Pick the role of the car",
-                    "Role", _carSettings.Role);
+                    "Cargo Role", _carSettings.Role);
             }
 
             EditorHelpers.DrawSeparator();

--- a/CCL.Creator/Wizards/CarWizard.cs
+++ b/CCL.Creator/Wizards/CarWizard.cs
@@ -243,6 +243,8 @@ namespace CCL.Creator.Wizards
             livery.FrontBogie = GetBogieFromBase(settings.BaseCarType);
             livery.RearBogie = livery.FrontBogie;
             livery.parentType = carType;
+            livery.DemonstratorPartName = TranslationData.Default($"{settings.Name} Drivetrain");
+            livery.DemonstratorPartNameShort = TranslationData.Default($"{settings.Name} Drivetrain");
 
             carType.liveries = new List<CustomCarVariant>() { livery };
             carType.ForceValidation();

--- a/CCL.Creator/Wizards/CargoWizard.cs
+++ b/CCL.Creator/Wizards/CargoWizard.cs
@@ -329,7 +329,7 @@ namespace CCL.Creator.Wizards
 
         #region Mass Visualiser
 
-        private static Dictionary<string, float> s_massMap = new Dictionary<string, float>()
+        private static readonly Dictionary<string, float> s_massMap = new Dictionary<string, float>()
         {
             { "Coal", 56000 },
             { "IronOre", 62000 },
@@ -438,10 +438,75 @@ namespace CCL.Creator.Wizards
             { "EmptyChemlek", 6000 },
             { "EmptyNeoGamma", 6000 },
             // Pax mod.
-            { OtherMods.PassengerJobs.CARGO_ID, OtherMods.PassengerJobs.CARGO_MASS }
+            { OtherMods.PassengerJobs.CARGO_ID, OtherMods.PassengerJobs.CARGO_MASS },
+            // Other cargo mods.
+            { OtherMods.GenericContainerCargo.EMPTY_ID, OtherMods.GenericContainerCargo.EMPTY_MASS },
+            { OtherMods.GenericContainerCargo.CHEMICALS_ID, OtherMods.GenericContainerCargo.CHEMICALS_MASS },
+            { OtherMods.GenericContainerCargo.CLOTHING_ID, OtherMods.GenericContainerCargo.CLOTHING_MASS },
+            { OtherMods.GenericContainerCargo.ELECTRONICS_ID, OtherMods.GenericContainerCargo.ELECTRONICS_MASS },
+            { OtherMods.GenericContainerCargo.TOOLING_ID, OtherMods.GenericContainerCargo.TOOLING_MASS },
+        };
+        private static readonly Dictionary<string, int> s_unitMap = new Dictionary<string, int>()
+        {
+            { "ScrapContainers", 1 },
+            { "ElectronicsIskar", 1 },
+            { "ElectronicsKrugmann", 1 },
+            { "ElectronicsAAG", 1 },
+            { "ElectronicsNovae", 1 },
+            { "ElectronicsTraeg", 1 },
+            { "ToolsIskar", 1 },
+            { "ToolsBrohm", 1 },
+            { "ToolsAAG", 1 },
+            { "ToolsNovae", 1 },
+            { "ToolsTraeg", 1 },
+            { "ClothingObco", 1 },
+            { "ClothingNeoGamma", 1 },
+            { "ClothingNovae", 1 },
+            { "ClothingTraeg", 1 },
+            { "ChemicalsIskar", 1 },
+            { "ChemicalsSperex", 1 },
+            { "NewCars", 10 },
+            { "ImportedNewCars", 8 },
+            { "Tractors", 3 },
+            { "Excavators", 1 },
+            { "MiningTrucks", 1 },
+            { "CityBuses", 1 },
+            { "SemiTrailers", 1 },
+            { "Trams", 1 },
+            { "ForestryTrailers", 2 },
+            { "Tanks", 1 },
+            { "MilitaryTrucks", 2 },
+            { "AttackHelicopsters", 1 },
+            { "Missiles", 1 },
+            { "MilitaryCars", 3 },
+            { "TrainPartsDE2", 1 },
+            { "TrainPartsDE6", 1 },
+            { "TrainPartsDH4", 1 },
+            { "TrainPartsDM3", 1 },
+            { "TrainPartsS060", 1 },
+            { "TrainPartsS282A", 1 },
+            { "EmptySunOmni", 1 },
+            { "EmptyIskar", 1 },
+            { "EmptyObco", 1 },
+            { "EmptyGoorsk", 1 },
+            { "EmptyKrugmann", 1 },
+            { "EmptyBrohm", 1 },
+            { "EmptyAAG", 1 },
+            { "EmptySperex", 1 },
+            { "EmptyNovae", 1 },
+            { "EmptyTraeg", 1 },
+            { "EmptyChemlek", 1 },
+            { "EmptyNeoGamma", 1 },
+            // Pax mod.
+            { OtherMods.PassengerJobs.CARGO_ID, 68 },
+            // Other cargo mods.
+            { OtherMods.GenericContainerCargo.EMPTY_ID, 1 },
+            { OtherMods.GenericContainerCargo.CHEMICALS_ID, 1 },
+            { OtherMods.GenericContainerCargo.CLOTHING_ID, 1 },
+            { OtherMods.GenericContainerCargo.ELECTRONICS_ID, 1 },
+            { OtherMods.GenericContainerCargo.TOOLING_ID, 1 },
         };
 
-        private const int DefaultPassengerCount = 68;
         private const float Size1 = 100;
         private const float Size2 = 70;
 
@@ -476,6 +541,7 @@ namespace CCL.Creator.Wizards
             }
 
             EditorGUILayout.EndScrollView();
+            EditorGUIUtility.labelWidth = 0;
             GUI.enabled = HasSetup;
 
             if (GUILayout.Button("Reset All to Default") && _setup != null)
@@ -514,26 +580,26 @@ namespace CCL.Creator.Wizards
 
             EditorGUILayout.EndHorizontal();
 
-            if (entry.CargoId == OtherMods.PassengerJobs.CARGO_ID)
+            if (s_unitMap.TryGetValue(entry.CargoId, out var units))
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.BeginHorizontal();
                 EditorGUI.BeginChangeCheck();
-                var paxCount = EditorGUILayout.IntField("Number of Passengers", Mathf.RoundToInt(entry.AmountPerCar * DefaultPassengerCount));
+                var count = EditorGUILayout.IntField("Units", Mathf.RoundToInt(entry.AmountPerCar * units));
 
                 if (EditorGUI.EndChangeCheck())
                 {
-                    entry.AmountPerCar = (float)paxCount / DefaultPassengerCount;
+                    entry.AmountPerCar = (float)count / units;
                 }
 
-                EditorGUILayout.Space(Size1 - 16);
+                EditorGUILayout.LabelField(string.Empty, _widthMassColumn);
                 EditorGUILayout.EndHorizontal();
                 EditorGUI.indentLevel--;
             }
 
             // Amount can't be less than 0.
             entry.AmountPerCar = Mathf.Max(0, entry.AmountPerCar);
-            EditorGUIUtility.labelWidth = 0;
+            EditorGUILayout.Space();
         }
 
         #endregion

--- a/CCL.Creator/Wizards/CargoWizard.cs
+++ b/CCL.Creator/Wizards/CargoWizard.cs
@@ -30,7 +30,7 @@ namespace CCL.Creator.Wizards
             new GUIContent("Set Prefabs",
                 "Assign prefabs to cargo automatically"),
             new GUIContent("Mass Visualiser",
-                "Check cargo masses and multipliers")
+                "Change cargo mass or amount directly")
         };
 
         private SerializedObject _editor = null!;

--- a/CCL.Creator/Wizards/CargoWizard.cs
+++ b/CCL.Creator/Wizards/CargoWizard.cs
@@ -436,41 +436,98 @@ namespace CCL.Creator.Wizards
             { "EmptyNovae", 6000 },
             { "EmptyTraeg", 6000 },
             { "EmptyChemlek", 6000 },
-            { "EmptyNeoGamma", 6000 }
+            { "EmptyNeoGamma", 6000 },
+            // Pax mod.
+            { OtherMods.PassengerJobs.CARGO_ID, OtherMods.PassengerJobs.CARGO_MASS }
         };
+
+        private const int DefaultPassengerCount = 68;
+        private const float Size1 = 100;
+        private const float Size2 = 70;
+
+        private Vector2 _massScroll = Vector2.zero;
+        private GUILayoutOption _widthMassColumn = GUILayout.Width(Size1);
 
         private void DrawMassVisualiser()
         {
             EditorGUI.BeginChangeCheck();
 
+            var widthWindow = EditorGUIUtility.currentViewWidth - 14;
+            EditorGUIUtility.labelWidth = widthWindow - Size1 - Size2;
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Cargo ID", "Amount");
+            EditorGUILayout.LabelField("Mass (kg)", _widthMassColumn);
+            EditorGUILayout.EndHorizontal();
+
+            _massScroll = EditorGUILayout.BeginScrollView(_massScroll);
+
             foreach (var item in _setup.Entries)
             {
-                DrawMass(item);
+                DrawMass(item, widthWindow);
             }
 
             if (EditorGUI.EndChangeCheck())
             {
                 SaveChanges();
             }
+
+            EditorGUILayout.EndScrollView();
+
+            if (GUILayout.Button("Reset All to Default"))
+            {
+                foreach (var item in _setup.Entries)
+                {
+                    item.AmountPerCar = 1;
+                }
+
+                SaveChanges();
+            }
         }
 
-        private void DrawMass(CargoEntry entry)
+        private void DrawMass(CargoEntry entry, float widthWindow)
         {
             EditorGUILayout.BeginHorizontal();
 
-            entry.AmountPerCar = EditorGUILayout.FloatField(entry.AmountPerCar, GUILayout.Width(60.0f));
+            entry.AmountPerCar = EditorGUILayout.FloatField(entry.CargoId, entry.AmountPerCar);
 
             if (s_massMap.TryGetValue(entry.CargoId, out float mass))
             {
-                mass /= 1000.0f;
-                EditorGUILayout.LabelField(entry.CargoId, $"{mass * entry.AmountPerCar:F2}/{mass:F2} t");
+                EditorGUI.BeginChangeCheck();
+                var scaledMass = EditorGUILayout.FloatField(mass * entry.AmountPerCar, _widthMassColumn);
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    entry.AmountPerCar = scaledMass / mass;
+                }
             }
             else
             {
-                EditorGUILayout.LabelField(entry.CargoId, $"Unknown Mass");
+                EditorGUILayout.LabelField("Unknown", _widthMassColumn);
             }
 
             EditorGUILayout.EndHorizontal();
+
+            if (entry.CargoId == OtherMods.PassengerJobs.CARGO_ID)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.BeginHorizontal();
+                EditorGUI.BeginChangeCheck();
+                var paxCount = EditorGUILayout.IntField("Number of Passengers", Mathf.RoundToInt(entry.AmountPerCar * DefaultPassengerCount));
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    entry.AmountPerCar = (float)paxCount / DefaultPassengerCount;
+                }
+
+                EditorGUILayout.Space(Size1 - 16);
+                EditorGUILayout.EndHorizontal();
+                EditorGUI.indentLevel--;
+            }
+
+            // Amount can't be less than 0.
+            entry.AmountPerCar = Mathf.Max(0, entry.AmountPerCar);
+            EditorGUIUtility.labelWidth = 0;
         }
 
         #endregion

--- a/CCL.Creator/Wizards/CargoWizard.cs
+++ b/CCL.Creator/Wizards/CargoWizard.cs
@@ -462,19 +462,23 @@ namespace CCL.Creator.Wizards
 
             _massScroll = EditorGUILayout.BeginScrollView(_massScroll);
 
-            foreach (var item in _setup.Entries)
+            if (_setup != null)
             {
-                DrawMass(item, widthWindow);
-            }
+                foreach (var item in _setup.Entries)
+                {
+                    DrawMass(item, widthWindow);
+                }
 
-            if (EditorGUI.EndChangeCheck())
-            {
-                SaveChanges();
+                if (EditorGUI.EndChangeCheck())
+                {
+                    SaveChanges();
+                }
             }
 
             EditorGUILayout.EndScrollView();
+            GUI.enabled = HasSetup;
 
-            if (GUILayout.Button("Reset All to Default"))
+            if (GUILayout.Button("Reset All to Default") && _setup != null)
             {
                 foreach (var item in _setup.Entries)
                 {
@@ -483,6 +487,8 @@ namespace CCL.Creator.Wizards
 
                 SaveChanges();
             }
+
+            GUI.enabled = true;
         }
 
         private void DrawMass(CargoEntry entry, float widthWindow)

--- a/CCL.Creator/Wizards/ConverterWizard.cs
+++ b/CCL.Creator/Wizards/ConverterWizard.cs
@@ -28,7 +28,7 @@ namespace CCL.Creator.Wizards
                 new ExtraUnit("Miles/hour", Units.MPHtoKMH),
                 new ExtraUnit("Metres/second", Units.KMHtoMS)),
 
-            new ConvertBase("Mass", "Kilogram",
+            new ConvertBase("Mass", "Kilograms",
                 new ExtraUnit("Pounds", Units.LBtoKG),
                 new ExtraUnit("Tonnes", Units.FromKilo),
                 new ExtraUnit("Long Tons", Units.LongTtoKG),

--- a/CCL.Creator/Wizards/NamingWizard.cs
+++ b/CCL.Creator/Wizards/NamingWizard.cs
@@ -257,6 +257,7 @@ namespace CCL.Creator.Wizards
                     _capacity = 1;
                     _powerRating = 3;
                     _decade = 8;
+                    _multipleWorking = Random.Range(1, 5);
                     break;
                 // BE2-260
                 case 13:

--- a/CCL.Creator/Wizards/NamingWizard.cs
+++ b/CCL.Creator/Wizards/NamingWizard.cs
@@ -133,7 +133,7 @@ namespace CCL.Creator.Wizards
             _isSlug = false;
             _multipleWorking = 0;
 
-            switch (Random.Range(0, 14))
+            switch (Random.Range(0, 16))
             {
                 // DE2-480
                 case 0:
@@ -199,6 +199,15 @@ namespace CCL.Creator.Wizards
                     _powerRating = 1;
                     _decade = 5;
                     break;
+                // DM1P-150
+                case 7:
+                    _powertrain = Powertrain.DM;
+                    _poweredAxles = 1;
+                    _totalAxles = 2;
+                    _capacity = 1;
+                    _powerRating = 1;
+                    _decade = 5;
+                    break;
                 // S060-440
                 case 8:
                     _powertrain = Powertrain.S;
@@ -240,8 +249,17 @@ namespace CCL.Creator.Wizards
                     _powerRating = 9;
                     _decade = 6;
                     break;
-                // BE2-260
+                // WE2P-380
                 case 12:
+                    _powertrain = Powertrain.WE;
+                    _poweredAxles = 2;
+                    _totalAxles = 4;
+                    _capacity = 1;
+                    _powerRating = 3;
+                    _decade = 8;
+                    break;
+                // BE2-260
+                case 13:
                     _powertrain = Powertrain.BE;
                     _poweredAxles = 2;
                     _totalAxles = 2;
@@ -250,7 +268,7 @@ namespace CCL.Creator.Wizards
                     _decade = 6;
                     break;
                 // H1-020
-                case 13:
+                case 14:
                     _powertrain = Powertrain.H;
                     _poweredAxles = 1;
                     _totalAxles = 2;

--- a/CCL.Importer/CCLPlugin.cs
+++ b/CCL.Importer/CCLPlugin.cs
@@ -42,7 +42,7 @@ namespace CCL.Importer
             if (!VersionCheck())
             {
                 Error($"Game version failure!\nGame: {BuildInfo.BUILDBOT_INFO}\nExpected: {ExporterConstants.MINIMUM_DV_BUILD}");
-                CarManager.LoadFailures.Add("[CCL] Unsupported version");
+                CarManager.LoadFailures.Add("[CCL] Unsupported game version");
                 ObjectHelper.CreateFailuresHolder();
                 return false;
             }

--- a/CCL.Importer/CCLPlugin.cs
+++ b/CCL.Importer/CCLPlugin.cs
@@ -13,7 +13,7 @@ namespace CCL.Importer
     {
         public const string Guid = "cc.foxden.customcarloader";
         public const string Name = "Custom Car Loader";
-        public const string Version = "3.1.7";
+        public const string Version = "3.1.9";
 
         public const string ContentFolderName = "content";
         public const string CarFolderName = "cars";

--- a/CCL.Importer/CCLPlugin.cs
+++ b/CCL.Importer/CCLPlugin.cs
@@ -47,6 +47,13 @@ namespace CCL.Importer
                 return false;
             }
 
+            if (UnityModManager.modEntries.Any(IsBadNumberManager))
+            {
+                Warning("===============\n\n\n\n\nCCL AND NUMBER MANAGER DETECTED\n\n\n\n\n===============");
+                CarManager.LoadFailures.Add("[CCL] Number Manager detected. All CCL bug reports are invalid from now on");
+                ObjectHelper.CreateFailuresHolder();
+            }
+
             // Build caches before any car is loaded, to only get vanilla resources.
             Processing.GrabberProcessor.BuildAllCaches();
 
@@ -119,5 +126,15 @@ namespace CCL.Importer
         }
 
         private static bool VersionCheck() => int.Parse(BuildInfo.BUILDBOT_INFO.Substring(5)) >= ExporterConstants.BUILD_INT;
+
+        internal static bool IsBadNumberManager(UnityModManager.ModEntry modEntry)
+        {
+            if (modEntry.Active && modEntry.Info.Id == "NumberManager")
+            {
+                return new System.Version(modEntry.Info.Version) <= new System.Version(4, 0, 2);
+            }
+
+            return false;
+        }
     }
 }

--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -107,7 +107,7 @@ namespace CCL.Importer
                 CCLPlugin.Error($"Pack {pack.PackId} was built with a newer version of CCL:\n" +
                     $"Current Version = {ExporterConstants.ExporterVersion}\n" +
                     $"Pack Version = {version}");
-                LoadFailures.Add($"[Pack] {pack.PackId} ({version} > {ExporterConstants.ExporterVersion})");
+                LoadFailures.Add($"[Pack] {pack.PackId} (outdated CCL: {version} > {ExporterConstants.ExporterVersion})");
                 return loaded;
             }
             else if (version < ExporterConstants.MinimumCompatibleVersion)
@@ -115,7 +115,7 @@ namespace CCL.Importer
                 CCLPlugin.Error($"Pack {pack.PackId} was built with an incompatible version of CCL:\n" +
                     $"Minimum Version = {ExporterConstants.MinimumCompatibleVersion}\n" +
                     $"Pack Version = {version}");
-                LoadFailures.Add($"[Pack] {pack.PackId} ({version} < {ExporterConstants.MinimumCompatibleVersion})");
+                LoadFailures.Add($"[Pack] {pack.PackId} (outdated mod: {version} < {ExporterConstants.MinimumCompatibleVersion})");
                 return loaded;
             }
 
@@ -151,7 +151,7 @@ namespace CCL.Importer
                     }
                     else
                     {
-                        LoadFailures.Add($"[Car] {car.id} ({pack.PackId})");
+                        LoadFailures.Add($"[Car] {car.id} ({pack.PackId} - generic failure, check log)");
                     }
                 }
 
@@ -166,7 +166,7 @@ namespace CCL.Importer
             catch (Exception e)
             {
                 CCLPlugin.Error($"Error loading pack {pack.PackId}:\n{e}");
-                LoadFailures.Add($"[Pack] {pack.PackId} (exception)");
+                LoadFailures.Add($"[Pack] {pack.PackId} (exception: {e.Message})");
             }
 
             return loaded;

--- a/CCL.Importer/CarManager.cs
+++ b/CCL.Importer/CarManager.cs
@@ -59,6 +59,13 @@ namespace CCL.Importer
         {
             if (newState)
             {
+                if (CCLPlugin.IsBadNumberManager(modEntry))
+                {
+                    CCLPlugin.Warning("===============\n\n\n\n\nCCL AND NUMBER MANAGER DETECTED\n\n\n\n\n===============");
+                    LoadFailures.Add("[CCL] Number Manager detected. All CCL bug reports are invalid from now on");
+                    ObjectHelper.CreateFailuresHolder();
+                }
+
                 LoadCarDefinitions(modEntry);
             }
         }

--- a/CCL.Importer/CarTypeInjector.cs
+++ b/CCL.Importer/CarTypeInjector.cs
@@ -38,6 +38,9 @@ namespace CCL.Importer
                     CCLPlugin.Translations.AddTranslations(livery.CatalogPageNameTranslationKey, livery.CatalogPage.PageName);
                     CCLPlugin.Translations.AddTranslations(livery.CatalogNicknameTranslationKey, livery.CatalogPage.Nickname);
                 }
+
+                CCLPlugin.Translations.AddTranslations(livery.DemoPartsNameTranslationKey, livery.DemonstratorPartName);
+                CCLPlugin.Translations.AddTranslations(livery.DemoPartsNameShortTranslationKey, livery.DemonstratorPartNameShort);
             }
 
             CargoInjector.InjectLoadableCargos(carType);

--- a/CCL.Importer/CarTypeInjector.cs
+++ b/CCL.Importer/CarTypeInjector.cs
@@ -1,5 +1,6 @@
 ﻿using CCL.Importer.Types;
 using DV;
+using DVLangHelper.Data;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -39,13 +40,26 @@ namespace CCL.Importer
                     CCLPlugin.Translations.AddTranslations(livery.CatalogNicknameTranslationKey, livery.CatalogPage.Nickname);
                 }
 
-                CCLPlugin.Translations.AddTranslations(livery.DemoPartsNameTranslationKey, livery.DemonstratorPartName);
-                CCLPlugin.Translations.AddTranslations(livery.DemoPartsNameShortTranslationKey, livery.DemonstratorPartNameShort);
+                if (IsValidTranslation(livery.DemonstratorPartName))
+                {
+                    CCLPlugin.Translations.AddTranslations(livery.DemoPartsNameTranslationKey, livery.DemonstratorPartName);
+                }
+                if (IsValidTranslation(livery.DemonstratorPartNameShort))
+                {
+                    CCLPlugin.Translations.AddTranslations(livery.DemoPartsNameShortTranslationKey, livery.DemonstratorPartNameShort);
+                }
             }
 
             CargoInjector.InjectLoadableCargos(carType);
 
             return true;
+        }
+
+        private static bool IsValidTranslation(TranslationData? data)
+        {
+            if (data == null || data.Items.Count == 0) return false;
+
+            return !data.Items.All(x => string.IsNullOrEmpty(x.Value));
         }
     }
 }

--- a/CCL.Importer/CargoInjector.cs
+++ b/CCL.Importer/CargoInjector.cs
@@ -5,6 +5,7 @@ using CCL.Types;
 using DV;
 using DV.ThingTypes;
 using HarmonyLib;
+using System.Linq;
 using UnityEngine;
 
 namespace CCL.Importer
@@ -23,7 +24,13 @@ namespace CCL.Importer
 
                 if (!Globals.G.Types.TryGetCargo(entry.CargoId, out var matchCargo))
                 {
-                    CCLPlugin.Error($"Couldn't find  cargo '{entry.CargoId}'");
+                    CCLPlugin.Error($"Couldn't find cargo '{entry.CargoId}'");
+                    continue;
+                }
+
+                if (matchCargo.loadableCarTypes.Any(x => x.carType == carType))
+                {
+                    CCLPlugin.Error($"Cargo '{entry.CargoId}' already has entry for car '{carType.id}', skipping");
                     continue;
                 }
 

--- a/CCL.Importer/CatalogGenerator.cs
+++ b/CCL.Importer/CatalogGenerator.cs
@@ -171,7 +171,7 @@ namespace CCL.Importer
                 if (StationSpawnChanceData.Data.TryGetValue(item.id, out var chances))
                 {
                     // Get the chance for this ID.
-                    var chance = chances.GetChance(livery);
+                    var chance = chances.GetChance(livery.parentType);
 
                     if (chance > 0)
                     {

--- a/CCL.Importer/CatalogGenerator.cs
+++ b/CCL.Importer/CatalogGenerator.cs
@@ -294,6 +294,17 @@ namespace CCL.Importer
             layout = Object.Instantiate(layout, root);
             layout.localPosition = new Vector3(DiagramComponent.WIDTH, DiagramComponent.HEIGHT, 0);
 
+            foreach (var body in layout.GetComponentsInChildren<VehicleBody>())
+            {
+                // This is needed so the extra body parts are always behind the rest.
+                body.transform.SetParent(root, true);
+                body.transform.SetAsFirstSibling();
+
+                var instance = (RectTransform)Object.Instantiate(root.Find(Paths.Diagrams.TallVehicle), body.transform);
+                instance.gameObject.SetActive(true);
+                instance.sizeDelta = body.RectTransform.sizeDelta;
+            }
+
             foreach (var bogie in layout.GetComponentsInChildren<BogieLayout>())
             {
                 if (bogie.Wheels.Length == 0)

--- a/CCL.Importer/Components/CustomComponentReplacer.cs
+++ b/CCL.Importer/Components/CustomComponentReplacer.cs
@@ -79,6 +79,7 @@ namespace CCL.Importer.Components
             CreateMap<MultipleFuseLogicDefinition, MultipleFuseLogicDefinitionInternal>().AutoCacheAndMap();
             CreateMap<ConstantMultiplierOffsetDefinition, ConstantMultiplierOffsetDefinitionInternal>().AutoCacheAndMap();
             CreateMap<RPMDamageCalculatorDefinition, RPMDamageCalculatorDefinitionInternal>().AutoCacheAndMap();
+            CreateMap<FlywheelDefinition, FlywheelDefinitionInternal>().AutoCacheAndMap();
 
             // Electric.
             CreateMap<BatteryCustomCurveDefinition, BatteryCustomCurveDefinitionInternal>().AutoCacheAndMap();

--- a/CCL.Importer/Components/KeepCoupledInteriorLoadedInternal.cs
+++ b/CCL.Importer/Components/KeepCoupledInteriorLoadedInternal.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using DV.Tutorial.QT;
 using UnityEngine;
 
 namespace CCL.Importer.Components
@@ -102,6 +102,8 @@ namespace CCL.Importer.Components
 
         private void LockLOD()
         {
+            if (QuickTutorialHost.IsTutorialRunning) return;
+
             if (_coupledF != null && KeepFrontCoupledLoaded)
             {
                 _coupledF.physicsLod.LockHighestLOD();
@@ -115,6 +117,8 @@ namespace CCL.Importer.Components
 
         private void UnlockLOD(bool front, bool rear)
         {
+            if (QuickTutorialHost.IsTutorialRunning) return;
+
             if (_coupledF != null && front)
             {
                 _coupledF.physicsLod.UnlockHighestLOD();

--- a/CCL.Importer/Components/Simulation/FlywheelDefinitionInternal.cs
+++ b/CCL.Importer/Components/Simulation/FlywheelDefinitionInternal.cs
@@ -1,0 +1,25 @@
+﻿using CCL.Importer.Implementations;
+using LocoSim.Definitions;
+using LocoSim.Implementations;
+
+namespace CCL.Importer.Components.Simulation
+{
+    internal class FlywheelDefinitionInternal : SimComponentDefinition
+    {
+        public float RotationalInertia = 100;
+        public float ViscousDampingFactor = 50;
+        public float MaxRPM;
+
+        public readonly PortDefinition RPM = new(PortType.READONLY_OUT, PortValueType.RPM, "RPM");
+        public readonly PortDefinition RPMNormalised = new(PortType.READONLY_OUT, PortValueType.RPM, "RPM_NORMALIZED");
+        public readonly PortDefinition RPMAbsolute = new(PortType.READONLY_OUT, PortValueType.RPM, "RPM_ABS");
+        public readonly PortDefinition RPMAbsoluteNormalised = new(PortType.READONLY_OUT, PortValueType.RPM, "RPM_ABS_NORMALIZED");
+        public readonly PortDefinition TorqueIn = new(PortType.IN, PortValueType.TORQUE, "TORQUE_IN");
+        public readonly PortReferenceDefinition LoadTorque = new(PortValueType.TORQUE, "LOAD_TORQUE");
+
+        public override SimComponent InstantiateImplementation()
+        {
+            return new Flywheel(this);
+        }
+    }
+}

--- a/CCL.Importer/Console.cs
+++ b/CCL.Importer/Console.cs
@@ -3,11 +3,8 @@ using CommandTerminal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Runtime.Remoting.Channels;
 using System.Text;
 using UnityEngine;
-using static DV.UI.ATutorialsMenuProvider;
 
 namespace CCL.Importer
 {
@@ -158,16 +155,51 @@ namespace CCL.Importer
         [RegisterCommand("CCL.SpawnChance",
             Help = "Calculates the spawn chance of a locomotive spawning at a station\nUse \"ALL\" in place of the station ID to show chances on all stations",
             Hint = "CCL.SpawnChance HB LocoS282B T",
-            MinArgCount = 2, MaxArgCount = 3)]
+            MinArgCount = 1, MaxArgCount = 3)]
         public static void CalculateSpawnChance(CommandArg[] args)
         {
-            if (args.Length < 2)
+            var station = args[0].String.ToUpper();
+
+            // Just station ID, so show all liveries that spawn in it.
+            if (args.Length == 1)
             {
-                Debug.LogError("Missing arguments!");
+                if (StationSpawnChanceData.Data.TryGetValue(station, out var data))
+                {
+                    var sb = new StringBuilder($"Listing all spawn chances for station '{station}':");
+                    var list = new List<(string S, float CL, float CT)>();
+                    var flag = true;
+
+                    foreach (var item in data.GetAllLiveries())
+                    {
+                        var chanceT = data.GetChance(item.parentType);
+                        var chanceL = data.GetChance(item);
+
+                        if (chanceT <= 0) continue;
+                        if (chanceT != chanceL) flag = false;
+
+                        list.Add((item.id, chanceL, chanceT));
+                    }
+
+                    sb.Append(flag ? $"\n {"Livery ID",-32} |   Type" : $"\n {"Livery ID",-32} |  Livery  |   Type");
+                    list.Sort();
+
+                    foreach (var (s, cl, ct) in list)
+                    {
+                        sb.Append(flag ? $"\n {s,-32} | {ct,8:P1}" : $"\n {s,-32} | {cl,8:P1} | {ct,8:P1}");
+                    }
+
+                    Debug.Log(sb.ToString());
+                }
+                else
+                {
+                    Debug.LogWarning($"Could not find station '{station}'");
+                }
+
                 return;
             }
 
-            string id = args[1].String;
+            // From here we need the livery ID, so check if it exists.
+            var id = args[1].String;
 
             if (!DV.Globals.G.Types.TryGetLivery(id, out var livery))
             {
@@ -175,6 +207,7 @@ namespace CCL.Importer
                 return;
             }
 
+            // Check if there's a sorting mode argument.
             int sort = 0;
 
             if (args.Length > 2)
@@ -193,8 +226,8 @@ namespace CCL.Importer
                 }
             }
 
-            var station = args[0].String.ToUpper();
-
+            // If the station ID is "ALL", show the livery on all stations.
+            // Else just show it in the relevant station, if it exists.
             if (station == "ALL")
             {
                 var sb = new StringBuilder($"Listing all spawn chances for livery '{id}':");

--- a/CCL.Importer/Console.cs
+++ b/CCL.Importer/Console.cs
@@ -1,9 +1,13 @@
 ﻿using CCL.Importer.Components;
 using CommandTerminal;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.Remoting.Channels;
 using System.Text;
 using UnityEngine;
+using static DV.UI.ATutorialsMenuProvider;
 
 namespace CCL.Importer
 {
@@ -152,9 +156,9 @@ namespace CCL.Importer
         }
 
         [RegisterCommand("CCL.SpawnChance",
-            Help = "Calculates the spawn chance of a locomotive spawning at a station",
-            Hint = "CCL.SpawnChance HB LocoS282B",
-            MinArgCount = 2, MaxArgCount = 2)]
+            Help = "Calculates the spawn chance of a locomotive spawning at a station\nUse \"ALL\" in place of the station ID to show chances on all stations",
+            Hint = "CCL.SpawnChance HB LocoS282B T",
+            MinArgCount = 2, MaxArgCount = 3)]
         public static void CalculateSpawnChance(CommandArg[] args)
         {
             if (args.Length < 2)
@@ -163,20 +167,97 @@ namespace CCL.Importer
                 return;
             }
 
-            if (StationSpawnChanceData.Data.TryGetValue(args[0].String, out var data))
+            string id = args[1].String;
+
+            if (!DV.Globals.G.Types.TryGetLivery(id, out var livery))
             {
-                if (DV.Globals.G.Types.TryGetLivery(args[1].String, out var livery))
+                Debug.LogWarning($"Could not find livery '{id}'");
+                return;
+            }
+
+            int sort = 0;
+
+            if (args.Length > 2)
+            {
+                switch (args[2].String.ToLower())
                 {
-                    Debug.Log($"Spawn chance for livery '{args[1].String}' at '{args[0].String}' is {data.GetChance(livery):P1}");
+                    case "l":
+                        sort = 1;
+                        break;
+                    case "t":
+                        sort = 2;
+                        break;
+                    default:
+                        Debug.LogWarning($"Unknown sort type '{args[2].String}', default to alphabetical");
+                        break;
+                }
+            }
+
+            var station = args[0].String.ToUpper();
+
+            if (station == "ALL")
+            {
+                var sb = new StringBuilder($"Listing all spawn chances for livery '{id}':");
+                var list = new List<(string S, float CL, float CT)>();
+                var flag = true;
+
+                foreach (var data in StationSpawnChanceData.Data)
+                {
+                    var chanceT = data.Value.GetChance(livery.parentType);
+                    var chanceL = data.Value.GetChance(livery);
+
+                    if (chanceT <= 0) continue;
+                    if (chanceT != chanceL) flag = false;
+
+                    list.Add((data.Key, chanceL, chanceT));
+                }
+
+                if (list.Count > 0)
+                {
+                    sb.Append(flag ? "\n Station  |   Type" : "\n Station  |  Livery  |   Type");
+                    list.Sort();
+
+                    switch (sort)
+                    {
+                        case 1:
+                            list = list.OrderBy(x => -x.CL).ToList();
+                            break;
+                        case 2:
+                            list = list.OrderBy(x => -x.CT).ToList();
+                            break;
+                        default:
+                            break;
+                    }
+
+                    foreach (var (s, cl, ct) in list)
+                    {
+                        sb.Append(flag ? $"\n {s,-8} | {ct,8:P1}" : $"\n {s,-8} | {cl,8:P1} | {ct,8:P1}");
+                    }
+
+                    Debug.Log(sb.ToString());
                 }
                 else
                 {
-                    Debug.LogWarning($"Could not find livery '{args[1].String}'");
+                    Debug.LogWarning($"Livery '{id}' does not spawn at any station");
+                }
+            }
+            else if (StationSpawnChanceData.Data.TryGetValue(station, out var data))
+            {
+                var chanceT = data.GetChance(livery.parentType);
+                var chanceL = data.GetChance(livery);
+
+                if (chanceT > 0)
+                {
+                    Debug.Log($"Spawn chance for livery '{id}' at '{station}' is: {chanceL:P1} / {chanceT:P1}");
+                }
+                else
+                {
+                    Debug.LogWarning($"Livery '{id}' does not spawn at {station}");
                 }
             }
             else
             {
-                Debug.LogWarning($"Could not find station '{args[0].String}'");
+                Debug.LogWarning($"Could not find station '{station}'");
             }
         }
     }

--- a/CCL.Importer/ExtendedPaymentData.cs
+++ b/CCL.Importer/ExtendedPaymentData.cs
@@ -1,0 +1,75 @@
+﻿using DV.ThingTypes;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CCL.Importer
+{
+    public class ExtendedPaymentData : PaymentCalculationData
+    {
+        public class TypeCargoData
+        {
+            public TrainCarType_v2 CarType;
+            public CargoType Cargo;
+            public int Count;
+
+            public TypeCargoData(StationProceduralJobGenerator.CarTypesPerCargoTypeData data)
+            {
+                CarType = data.carTypes.First().parentType;
+                Cargo = data.cargoType;
+                Count = data.carTypes.Count;
+            }
+
+            public TypeCargoData(TrainCarType_v2 carType, CargoType cargo, int count)
+            {
+                CarType = carType;
+                Cargo = cargo;
+                Count = count;
+            }
+        }
+
+        public List<TypeCargoData> ExtendedData;
+
+        public ExtendedPaymentData(Dictionary<TrainCarLivery, int> carsData, Dictionary<CargoType, int> cargoData)
+            : base(carsData, cargoData)
+        {
+            ExtendedData = new List<TypeCargoData>();
+        }
+
+        public static ExtendedPaymentData FromRegular(PaymentCalculationData original, List<StationProceduralJobGenerator.CarTypesPerCargoTypeData> carTypesPerCargoData)
+        {
+            var extended = new ExtendedPaymentData(original.carsData, original.cargoData);
+
+            if (carTypesPerCargoData == null) return extended;
+
+            foreach (var item in carTypesPerCargoData)
+            {
+                extended.ExtendedData.Add(new TypeCargoData(item));
+            }
+
+            return extended;
+        }
+
+        public static ExtendedPaymentData ForSingleCargoType(PaymentCalculationData original, List<TrainCarLivery> carTypes, CargoType cargoType)
+        {
+            var extended = new ExtendedPaymentData(original.carsData, original.cargoData);
+            var dict = new Dictionary<TrainCarType_v2, int>();
+
+            foreach (var livery in carTypes)
+            {
+                if (!dict.ContainsKey(livery.parentType))
+                {
+                    dict[livery.parentType] = 0;
+                }
+
+                dict[livery.parentType]++;
+            }
+
+            foreach (var item in dict)
+            {
+                extended.ExtendedData.Add(new TypeCargoData(item.Key, cargoType, item.Value));
+            }
+
+            return extended;
+        }
+    }
+}

--- a/CCL.Importer/Implementations/Flywheel.cs
+++ b/CCL.Importer/Implementations/Flywheel.cs
@@ -1,0 +1,57 @@
+﻿using CCL.Importer.Components.Simulation;
+using LocoSim.Implementations;
+using UnityEngine;
+
+namespace CCL.Importer.Implementations
+{
+    internal class Flywheel : SimComponent
+    {
+        private readonly float _rotationalInertia;
+        private readonly float _viscousDampingFactor;
+        private readonly float _maxRpm;
+        private Port _rpm;
+        private Port _rpmNormalised;
+        private Port _rpmAbs;
+        private Port _rpmAbsNormalised;
+        private Port _torqueIn;
+        private PortReference _loadTorque;
+
+        public Flywheel(FlywheelDefinitionInternal def) : base(def.ID)
+        {
+            _rotationalInertia = def.RotationalInertia;
+            _viscousDampingFactor = def.ViscousDampingFactor;
+            _maxRpm = def.MaxRPM;
+
+            _rpm = AddPort(def.RPM);
+            _rpmNormalised = AddPort(def.RPMNormalised);
+            _rpmAbs = AddPort(def.RPMAbsolute);
+            _rpmAbsNormalised = AddPort(def.RPMAbsoluteNormalised);
+
+            _torqueIn = AddPort(def.TorqueIn);
+            _loadTorque = AddPortReference(def.LoadTorque);
+        }
+
+        public override void Tick(float delta)
+        {
+            var rpm = _rpm.Value;
+            var damp = SimConsts.RPM_TO_RAD_PER_S * rpm * _viscousDampingFactor;
+            var torque = _torqueIn.Value - damp + _loadTorque.Value;
+
+            rpm += torque / _rotationalInertia * delta;
+
+            // So it settles down rather than have very small values.
+            if (rpm < 0.001 && rpm > -0.001)
+            {
+                rpm = 0;
+            }
+
+            var rpmNormalised = rpm / _maxRpm;
+
+            // Absolute RPM is provided directly just in case.
+            _rpm.Value = rpm;
+            _rpmNormalised.Value = rpmNormalised;
+            _rpmAbs.Value = Mathf.Abs(rpm);
+            _rpmAbsNormalised.Value = Mathf.Abs(rpmNormalised);
+        }
+    }
+}

--- a/CCL.Importer/Patches/CPatches.cs
+++ b/CCL.Importer/Patches/CPatches.cs
@@ -1,0 +1,56 @@
+﻿using CCL.Importer.Types;
+using DV.Booklets;
+using DV.ThingTypes;
+using DV.ThingTypes.TransitionHelpers;
+using HarmonyLib;
+using System.Collections.Generic;
+
+namespace CCL.Importer.Patches
+{
+    [HarmonyPatch(typeof(C))]
+    internal class CPatches
+    {
+        [HarmonyPrefix, HarmonyPatch(nameof(C.GetCarsTotalMass))]
+        private static bool GetCarsTotalMassPrefix(List<Car_data> cars, List<CargoType> cargoPerCar, ref float __result)
+        {
+            // Won't run the patch code so just execute the base method.
+            if (cars == null || cargoPerCar == null || cars.Count != cargoPerCar.Count) return true;
+
+            float total = 0f;
+            for (int i = 0; i < cars.Count; i++)
+            {
+                total += cars[i].carOnlyMass;
+            }
+
+            for (int j = 0; j < cargoPerCar.Count; j++)
+            {
+                var v2 = cargoPerCar[j].ToV2();
+                var data = cars[j];
+
+                if (v2 != null)
+                {
+                    if (data.type.parentType is CCL_CarType car)
+                    {
+                        if (car.CargoAmounts.TryGetValue(v2.id, out var mult))
+                        {
+                            if (mult != 1)
+                            {
+                                total += data.capacity * v2.massPerUnit * mult;
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            CCLPlugin.Error($"Could not get cargo '{v2.id}' amount for car type {car.id}! Using default calculation for mass");
+                        }
+                    }
+
+                    total += data.capacity * v2.massPerUnit;
+                }
+            }
+
+            __result = total;
+            return false;
+        }
+    }
+}

--- a/CCL.Importer/Patches/CargoContentPatches.cs
+++ b/CCL.Importer/Patches/CargoContentPatches.cs
@@ -1,0 +1,28 @@
+﻿using CCL.Importer.Types;
+using DV.ThingTypes;
+using DV.ThingTypes.TransitionHelpers;
+using HarmonyLib;
+
+namespace CCL.Importer.Patches
+{
+    [HarmonyPatch(typeof(CargoContent))]
+    internal class CargoContentPatches
+    {
+        [HarmonyPostfix, HarmonyPatch(nameof(CargoContent.OnCargoLoaded))]
+        private static void CargoLoadedPostfix(CargoContent __instance, CargoType cargoType)
+        {
+            // Don't do anything for non-CCL car types.
+            if (__instance.trainCar.carLivery.parentType is not CCL_CarType car) return;
+
+            var id = cargoType.ToV2().id;
+
+            if (!car.CargoAmounts.TryGetValue(id, out var mult))
+            {
+                CCLPlugin.Error($"Could not get cargo '{id}' amount for car type {car.id}! Defaulting to 1.");
+                return;
+            }
+
+            __instance.cargoMassFull = __instance.cargoMassCurrent *= mult;
+        }
+    }
+}

--- a/CCL.Importer/Patches/JobPaymentCalculatorPatches.cs
+++ b/CCL.Importer/Patches/JobPaymentCalculatorPatches.cs
@@ -1,0 +1,94 @@
+﻿using CCL.Importer.Types;
+using DV;
+using DV.ThingTypes;
+using DV.ThingTypes.TransitionHelpers;
+using HarmonyLib;
+using UnityEngine;
+
+namespace CCL.Importer.Patches
+{
+    [HarmonyPatch(typeof(JobPaymentCalculator))]
+    internal class JobPaymentCalculatorPatches
+    {
+        [HarmonyPrefix, HarmonyPatch(nameof(JobPaymentCalculator.CalculateJobPayment))]
+        private static bool CalculateJobPaymentPrefix(JobType jobType, float distanceInMeters, PaymentCalculationData paymentCalculationData, ref float __result)
+        {
+            if (paymentCalculationData is not ExtendedPaymentData data) return true;
+
+            // Car value is the same as the base.
+            int carCount = 0;
+            float carMass = 0;
+            float carPrice = 0;
+
+            foreach (var car in paymentCalculationData.carsData)
+            {
+                int count = car.Value;
+                var parentType = car.Key.parentType;
+                carMass += parentType.mass * count;
+                carPrice += parentType.damage.bodyPrice * count;
+                carCount += count;
+            }
+
+            int cargoCount = 0;
+            float cargoMass = 0;
+            float cargoValue = 0;
+            float cargoEnvPrice = 0;
+            float cargoSensitivityMod = 0;
+
+            // Original cargo calculation.
+            //foreach (var cargo in paymentCalculationData.cargoData)
+            //{
+            //    var v2 = cargo.Key.ToV2();
+            //    if (v2 == null) continue;
+
+            //    int count = cargo.Value;
+            //    cargoMass += v2.massPerUnit * count;
+            //    cargoValue += v2.fullDamagePrice * count;
+            //    cargoEnvPrice += v2.environmentDamagePrice * count;
+            //    cargoSensitivityMod += v2.sensitivityPaymentModifier * count;
+            //    cargoCount += count;
+            //}
+
+            foreach (var extended in data.ExtendedData)
+            {
+                var v2 = extended.Cargo.ToV2();
+                if (v2 == null) continue;
+
+                float mult = 1.0f;
+                cargoCount += extended.Count;
+
+                if (extended.CarType is CCL_CarType car)
+                {
+                    if (!car.CargoAmounts.TryGetValue(v2.id, out mult))
+                    {
+                        CCLPlugin.Error($"Could not get cargo '{v2.id}' amount for car type {car.id}! Defaulting to 1.");
+                        mult = 1;
+                    }
+                }
+
+                mult *= extended.Count;
+
+                cargoMass += v2.massPerUnit * mult;
+                cargoValue += v2.fullDamagePrice * mult;
+                cargoEnvPrice += v2.environmentDamagePrice * mult;
+                cargoSensitivityMod += v2.sensitivityPaymentModifier * extended.Count;
+            }
+
+            float distance = distanceInMeters * JobPaymentCalculator.DISTANCE_MULTIPLIER;
+            float payment = carMass * JobPaymentCalculator.CAR_MASS_MULTIPLIER +
+                carPrice * JobPaymentCalculator.CAR_VALUE_MULTIPLIER +
+                cargoMass * JobPaymentCalculator.CARGO_MASS_MULTIPLIER +
+                cargoValue * JobPaymentCalculator.CARGO_VALUE_MULTIPLIER +
+                cargoEnvPrice * JobPaymentCalculator.CARGO_ENVIRONMENT_DAMAGE_VALUE_MULTIPLIER;
+            float boringnessFactor = JobPaymentCalculator.GetBoringnessFactor(jobType);
+            float falloffFactor = JobPaymentCalculator.GetFalloffFactor(carCount);
+            int diff = Mathf.Max(carCount - cargoCount, 0);
+            float sensitivity = (cargoSensitivityMod + diff) / (cargoCount + diff);
+
+            __result = Mathf.Round((JobPaymentCalculator.BASE_PAYMENT + payment * distance * boringnessFactor * falloffFactor * sensitivity) *
+                Globals.G.GameParams.JobPaymentModifier);
+
+            return false;
+        }
+    }
+}

--- a/CCL.Importer/Patches/StationProceduralJobGeneratorPatches.cs
+++ b/CCL.Importer/Patches/StationProceduralJobGeneratorPatches.cs
@@ -93,6 +93,14 @@ namespace CCL.Importer.Patches
 
             return list;
         }
+
+        // Replace the job payment data with our own class.
+        [HarmonyPostfix, HarmonyPatch(nameof(StationProceduralJobGenerator.ExtractPaymentCalculationData))]
+        private static void ExtractPaymentCalculationDataPostix(List<CarTypesPerCargoTypeData> carTypesPerCargoData, ref PaymentCalculationData __result)
+        {
+            if (__result == null) return;
+            __result = ExtendedPaymentData.FromRegular(__result, carTypesPerCargoData);
+        }
     }
 
     [HarmonyPatch(typeof(StationProceduralJobGenerator))]

--- a/CCL.Importer/Patches/TrainMassControllerPatches.cs
+++ b/CCL.Importer/Patches/TrainMassControllerPatches.cs
@@ -1,0 +1,66 @@
+﻿using CCL.Importer.Types;
+using DV.ThingTypes;
+using DV.ThingTypes.TransitionHelpers;
+using HarmonyLib;
+using System.Reflection;
+
+namespace CCL.Importer.Patches
+{
+    [HarmonyPatch(typeof(TrainMassController))]
+    internal class TrainMassControllerPatches
+    {
+        private class CargoState
+        {
+            public CargoType_v2? CargoType;
+            public float OriginalMass;
+
+            public void SetStuff(CargoType_v2 cargo)
+            {
+                CargoType = cargo;
+                OriginalMass = CargoType.massPerUnit;
+            }
+
+            public void Reset()
+            {
+                if (CargoType == null) return;
+
+                CargoType.massPerUnit = OriginalMass;
+            }
+        }
+
+        // Pain of the overload wrapper...
+        [HarmonyTargetMethod]
+        private static MethodBase GetMethod() => typeof(TrainMassController).GetMethod(nameof(TrainMassController.UpdateTrainCarMass));
+
+        [HarmonyPrefix, HarmonyPatch]
+        private static void UpdateTrainCarMassPrefix(TrainMassController __instance, out CargoState __state)
+        {
+            __state = new CargoState();
+
+            // Don't do anything for non-CCL car types.
+            if (__instance.car.carLivery.parentType is not CCL_CarType car) return;
+
+            var cargo = __instance.car.LoadedCargo;
+            if (cargo == CargoType.None) return;
+
+            var v2 = cargo.ToV2();
+            if (!car.CargoAmounts.TryGetValue(v2.id, out var mult))
+            {
+                CCLPlugin.Error($"Could not get cargo '{v2.id}' amount for car type {car.id}! Defaulting to 1.");
+                return;
+            }
+
+            // Don't do anything and avoid the trouble.
+            if (mult == 1) return;
+
+            __state.SetStuff(v2);
+            v2.massPerUnit *= mult;
+        }
+
+        [HarmonyPostfix, HarmonyPatch]
+        private static void UpdateTrainCarMassPostfix(CargoState __state)
+        {
+            __state.Reset();
+        }
+    }
+}

--- a/CCL.Importer/ProceduralMaterialGenerator.cs
+++ b/CCL.Importer/ProceduralMaterialGenerator.cs
@@ -128,9 +128,17 @@ namespace CCL.Importer
             mat.SetVector(ShaderProps.SightGlassGlassTint, settings.GlassTint);
             mat.SetFloat(ShaderProps.SightGlassThickness, settings.PipeThickness);
 
+            TrySetTexture(mat, ShaderProps.MainTex, settings.BackgroundTexture);
+            TrySetTexture(mat, ShaderProps.SightGlassGlass, settings.GlassTexture);
+
             settings.Cache(mat);
 
             return mat;
+        }
+
+        private static void TrySetTexture(Material mat, int id, Texture2D? tex)
+        {
+            if (tex != null) mat.SetTexture(id, tex);
         }
     }
 }

--- a/CCL.Importer/StationSpawnChanceData.cs
+++ b/CCL.Importer/StationSpawnChanceData.cs
@@ -81,6 +81,11 @@ namespace CCL.Importer
             return chance;
         }
 
+        public HashSet<TrainCarLivery> GetAllLiveries()
+        {
+            return _spawnTracks.SelectMany(x => x.SpawnGroups.SelectMany(y => y.liveries)).ToHashSet();
+        }
+
         public static void AddData(string id, StationLocoSpawner spawner)
         {
             if (!Data.TryGetValue(id, out var data))

--- a/CCL.Importer/StationSpawnChanceData.cs
+++ b/CCL.Importer/StationSpawnChanceData.cs
@@ -21,24 +21,51 @@ namespace CCL.Importer
                 SpawnGroups = spawner.locoTypeGroupsToSpawn;
             }
 
+            public float GetChance(TrainCarType_v2 type)
+            {
+                // If there are no groups, chance is 0. Failsafe to prevent division by 0.
+                if (SpawnGroups.Count == 0) return 0.0f;
+                // Chance is # of groups with the type divided by total groups.
+                return SpawnGroups.Count(x => x.liveries.Any(l => l.parentType == type)) / (float)SpawnGroups.Count;
+            }
+
             public float GetChance(TrainCarLivery livery)
             {
                 // If there are no groups, chance is 0. Failsafe to prevent division by 0.
                 if (SpawnGroups.Count == 0) return 0.0f;
                 // Chance is # of groups with the livery divided by total groups.
-                return SpawnGroups.Count(x => x.liveries.Any(l => l.parentType == livery.parentType)) / (float)SpawnGroups.Count;
+                return SpawnGroups.Count(x => x.liveries.Any(l => l == livery)) / (float)SpawnGroups.Count;
             }
 
             // For debugging, displays the group in RUE without needing to check every livery individually.
             private string QuickString => $"[{string.Join("], [", SpawnGroups.Select(x => string.Join(", ", x.liveries.Select(l => l.id))))}]";
         }
 
-        private Dictionary<TrainCarLivery, float> _chances = new();
+        private Dictionary<TrainCarType_v2, float> _chancesT = new();
+        private Dictionary<TrainCarLivery, float> _chancesL = new();
         private List<StationSpawnTrack> _spawnTracks = new();
+
+        public float GetChance(TrainCarType_v2 type)
+        {
+            if (_chancesT.TryGetValue(type, out var chance)) return chance;
+
+            // Start inverted.
+            chance = 1.0f;
+
+            foreach (var track in _spawnTracks)
+            {
+                // Calculate chance of not spawning.
+                chance *= 1.0f - track.GetChance(type);
+            }
+
+            // Complement of chance of not spawning is the chance of spawning at least 1.
+            _chancesT[type] = chance = 1 - chance;
+            return chance;
+        }
 
         public float GetChance(TrainCarLivery livery)
         {
-            if (_chances.TryGetValue(livery, out var chance)) return chance;
+            if (_chancesL.TryGetValue(livery, out var chance)) return chance;
 
             // Start inverted.
             chance = 1.0f;
@@ -50,7 +77,7 @@ namespace CCL.Importer
             }
 
             // Complement of chance of not spawning is the chance of spawning at least 1.
-            _chances[livery] = chance = 1 - chance;
+            _chancesL[livery] = chance = 1 - chance;
             return chance;
         }
 

--- a/CCL.Importer/TutorialGenerator.cs
+++ b/CCL.Importer/TutorialGenerator.cs
@@ -533,6 +533,9 @@ namespace CCL.Importer
                 }
                 else
                 {
+                    // Reverser forward, since this was actually before the sander step.
+                    c.AddOverridableControl(InteriorControlsManager.ControlType.Reverser, 1f, 1f, QTSemantic.GoForward);
+
                     // Disengage brakes.
                     c.AddControl(InteriorControlsManager.ControlType.Handbrake, 0f, 0f, QTSemantic.Disengage);
                     c.AddOverridableControl(loco.brakeSystem.hasIndependentBrake ?

--- a/CCL.Importer/Types/CCL_CarVariant.cs
+++ b/CCL.Importer/Types/CCL_CarVariant.cs
@@ -23,16 +23,16 @@ namespace CCL.Importer.Types
         public bool HideBackCoupler;
 
         public string[] TrainsetLiveries = new string[0];
-        public int MaxRepeatedSpawn = 0;
-        public bool AllowOnRegionalRoutes = true;
-        public bool AllowOnExpressRoutes = true;
         public LocoSpawnGroup[] LocoSpawnGroups = new LocoSpawnGroup[0];
         public bool UnlockableAsWorkTrain = false;
         public float UnlockPrice = 30000.0f;
         public float SummonPrice = 5000.0f;
-        public float DemonstratorPartsOrderCost = 0f;
-        public float DemonstratorPartsInstallationCost = 0f;
         public CatalogPage? CatalogPage = null;
+        public int MaxRepeatedSpawn = 0;
+        public bool AllowOnRegionalRoutes = true;
+        public bool AllowOnExpressRoutes = true;
+        public float DemonstratorPartsOrderCost = 15000.0f;
+        public float DemonstratorPartsInstallationCost = 10000.0f;
 
         public bool UseCustomFrontBogie => FrontBogie == BogieType.Custom;
         public bool UseCustomRearBogie => RearBogie == BogieType.Custom;

--- a/CCL.Importer/Types/CCL_CarVariant.cs
+++ b/CCL.Importer/Types/CCL_CarVariant.cs
@@ -33,6 +33,9 @@ namespace CCL.Importer.Types
         public bool AllowOnExpressRoutes = true;
         public float DemonstratorPartsOrderCost = 15000.0f;
         public float DemonstratorPartsInstallationCost = 10000.0f;
+        public Texture2D? DemonstratorPoster;
+        public Sprite? DemonstratorIcon;
+        public Sprite? DemonstratorRustedIcon;
 
         public bool UseCustomFrontBogie => FrontBogie == BogieType.Custom;
         public bool UseCustomRearBogie => RearBogie == BogieType.Custom;

--- a/CCL.Importer/Types/CCL_CarVariant.cs
+++ b/CCL.Importer/Types/CCL_CarVariant.cs
@@ -33,15 +33,23 @@ namespace CCL.Importer.Types
         public bool AllowOnExpressRoutes = true;
         public float DemonstratorPartsOrderCost = 15000.0f;
         public float DemonstratorPartsInstallationCost = 10000.0f;
+        public TranslationData DemonstratorPartName = new();
+        public TranslationData DemonstratorPartNameShort = new();
         public Texture2D? DemonstratorPoster;
         public Sprite? DemonstratorIcon;
         public Sprite? DemonstratorRustedIcon;
+        public PartsCargoModel PartsModel = PartsCargoModel.GenericBox;
+        public GameObject? PartsCargoPrefabDM1U;
+        public GameObject? PartsCargoPrefabFlatbed;
+        public float PartsCargoMass = 10000.0f;
 
         public bool UseCustomFrontBogie => FrontBogie == BogieType.Custom;
         public bool UseCustomRearBogie => RearBogie == BogieType.Custom;
         public bool UseCustomBuffers => BufferType == BufferType.Custom;
         public string CatalogPageNameTranslationKey => $"ccl/vc/pagename/{id}";
         public string CatalogNicknameTranslationKey => $"ccl/vc/nickname/{id}";
+        public string DemoPartsNameTranslationKey => $"ccl/cargo/tp_{id}";
+        public string DemoPartsNameShortTranslationKey => $"ccl/cargo/tp_{id}";
 
         public IEnumerable<GameObject> AllPrefabs
         {

--- a/CCL.Types/Catalog/CatalogEnums.cs
+++ b/CCL.Types/Catalog/CatalogEnums.cs
@@ -19,16 +19,27 @@ namespace CCL.Types.Catalog
     public enum VehicleRole
     {
         None = 0,
+        [Tooltip("The vehicle can perform light shunting duties")]
         LightShunting = 10,
+        [Tooltip("The vehicle can perform heavy shunting duties")]
         HeavyShunting,
+        [Tooltip("The vehicle can perform light hauling duties")]
         LightHauling = 20,
+        [Tooltip("The vehicle can perform heavy hauling duties")]
         HeavyHauling,
+        [Tooltip("The vehicle supplies fuel/resources to another unit")]
         FuelSupply = 30,
+        [Tooltip("The vehicle transports specialised crew onboard itself")]
         CrewTransport = 40,
+        [Tooltip("The vehicle acts as support for a specialised crew")]
         CrewSupport,
+        [Tooltip("The vehicle transports passengers onboard itself")]
         PassengerTransport = 50,
+        [Tooltip("The vehicle transports freight onboard itself")]
         FreightTransport,
+        [Tooltip("The vehicle transports utilities/tools onboard itself")]
         UtilityTransport,
+        [Tooltip("The vehicle is used for track maintenance duties")]
         TrackMaintenance = 60
     }
 

--- a/CCL.Types/Catalog/Diagram/VehicleBody.cs
+++ b/CCL.Types/Catalog/Diagram/VehicleBody.cs
@@ -1,0 +1,51 @@
+﻿using UnityEngine;
+
+namespace CCL.Types.Catalog.Diagram
+{
+    [AddComponentMenu("CCL/Catalog/Vehicle Body")]
+    public class VehicleBody : DiagramComponent
+    {
+        private const float DM1U_TALL_WIDTH = 133.4f;
+
+        private static readonly float[] s_linesH = new float[]
+        {
+            -WIDTH + DM1U_TALL_WIDTH / 2,
+            0,
+            WIDTH - DM1U_TALL_WIDTH / 2,
+        };
+        private static readonly float[] s_linesV = new float[]
+        {
+            -HEIGHT + 90 / 2,
+            0,
+            HEIGHT - 90 / 2,
+        };
+        private static readonly float[] s_widths = new float[]
+        {
+            DM1U_TALL_WIDTH,
+            350
+        };
+        private static readonly float[] s_heights = new float[]
+        {
+            90,
+            150
+        };
+
+        //public void OnValidate()
+        //{
+        //    var rect = (RectTransform)transform;
+        //    var delta = rect.sizeDelta / 2;
+
+        //    rect.position = new Vector3(
+        //        Mathf.Clamp(rect.position.x, Mathf.Max(-WIDTH, rect.position.x - delta.x), Mathf.Max(WIDTH, rect.position.x + delta.x)),
+        //        Mathf.Clamp(rect.position.y, Mathf.Max(-HEIGHT, rect.position.y - delta.y), Mathf.Max(HEIGHT, rect.position.y + delta.y)),
+        //        0);
+        //}
+
+        public override void AlignToGrid()
+        {
+            var rect = (RectTransform)transform;
+            rect.position = new Vector3(s_linesH.ClosestTo(transform.position.x), s_linesV.ClosestTo(transform.position.y), 0);
+            rect.sizeDelta = new Vector2(s_widths.ClosestTo(rect.sizeDelta.x), s_heights.ClosestTo(rect.sizeDelta.y));
+        }
+    }
+}

--- a/CCL.Types/Components/Materials/GenerateSightGlass.cs
+++ b/CCL.Types/Components/Materials/GenerateSightGlass.cs
@@ -13,13 +13,18 @@ namespace CCL.Types.Components.Materials
         public Color LiquidTint = new Color(0.6673193f, 0.7704878f, 0.8679245f, 1f);
         public Color GlassTint = new Color(0.754717f, 0.6976369f, 0.494838f, 1f);
 
+        public Texture2D? BackgroundTexture;
+        public Texture2D? GlassTexture;
+
         public override bool AreSameSettings(GenerateSightGlass other)
         {
             return BackgroundTextureTiling == other.BackgroundTextureTiling &&
                 GlassTextureTiling == other.GlassTextureTiling &&
                 PipeThickness == other.PipeThickness &&
                 LiquidTint == other.LiquidTint &&
-                GlassTint == other.GlassTint;
+                GlassTint == other.GlassTint &&
+                BackgroundTexture == other.BackgroundTexture &&
+                GlassTexture == other.GlassTexture;
         }
     }
 }

--- a/CCL.Types/Components/Simulation/FlywheelDefinition.cs
+++ b/CCL.Types/Components/Simulation/FlywheelDefinition.cs
@@ -1,0 +1,28 @@
+﻿using CCL.Types.Proxies.Ports;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CCL.Types.Components.Simulation
+{
+    [AddComponentMenu("CCL/Components/Simulation/Flywheel Definition")]
+    public class FlywheelDefinition : SimComponentDefinitionProxy
+    {
+        public float RotationalInertia = 100;
+        public float ViscousDampingFactor = 50;
+        public float MaxRPM;
+
+        public override IEnumerable<PortDefinition> ExposedPorts => new[]
+        {
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.RPM, "RPM"),
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.RPM, "RPM_NORMALIZED"),
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.RPM, "RPM_ABS"),
+            new PortDefinition(DVPortType.READONLY_OUT, DVPortValueType.RPM, "RPM_ABS_NORMALIZED"),
+            new PortDefinition(DVPortType.IN, DVPortValueType.TORQUE, "TORQUE_IN")
+        };
+
+        public override IEnumerable<PortReferenceDefinition> ExposedPortReferences => new[]
+        {
+            new PortReferenceDefinition(DVPortValueType.TORQUE, "LOAD_TORQUE")
+        };
+    }
+}

--- a/CCL.Types/CustomCarPack.cs
+++ b/CCL.Types/CustomCarPack.cs
@@ -26,7 +26,11 @@ namespace CCL.Types
         public ProceduralMaterialDefinitions? ProceduralMaterials;
         public ExtraTranslations? ExtraTranslations;
         [Tooltip("Additional mod dependencies go here\n" +
-            "CCL will automatically add Custom Cargo, Custom Licenses, and Passenger Jobs if needed")]
+            "CCL will automatically add the following mods if needed:\n" +
+            "• Custom Cargo\n" +
+            "• Custom Licenses\n" +
+            "• Passenger Jobs\n" +
+            "• Gauge")]
         public List<string> AdditionalDependencies = new List<string>();
 
         [RenderMethodButtons, SerializeField]

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -85,9 +85,11 @@ namespace CCL.Types
         public Sprite? DemonstratorIcon;
         [Tooltip("Livery icon for the rusty demonstrator paint")]
         public Sprite? DemonstratorRustedIcon;
-        [Tooltip("The prefab for the parts cargo, when loaded on the DM1U")]
+        [Tooltip("The model to use for the demonstrator parts")]
+        public PartsCargoModel PartsModel = PartsCargoModel.GenericBox;
+        [Tooltip("The prefab for the parts cargo, when loaded on the DM1U"), EnableIf(nameof(UseCustomPartsModel))]
         public GameObject? PartsCargoPrefabDM1U;
-        [Tooltip("The prefab for the parts cargo, when loaded on the Utility Flatbed")]
+        [Tooltip("The prefab for the parts cargo, when loaded on the Utility Flatbed"), EnableIf(nameof(UseCustomPartsModel))]
         public GameObject? PartsCargoPrefabFlatbed;
         [Tooltip("The mass of the parts cargo")]
         public float PartsCargoMass = 10000.0f;
@@ -100,6 +102,7 @@ namespace CCL.Types
         public bool UseCustomFrontBogie => FrontBogie == BogieType.Custom;
         public bool UseCustomRearBogie => RearBogie == BogieType.Custom;
         public bool UseCustomBuffers => BufferType == BufferType.Custom;
+        public bool UseCustomPartsModel => PartsModel == PartsCargoModel.Custom;
 
         public IEnumerable<GameObject> AllPrefabs
         {

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -83,7 +83,9 @@ namespace CCL.Types
         public TranslationData DemonstratorPartName = new TranslationData();
         [Tooltip("The shortened name of the demonstrator parts cargo")]
         public TranslationData DemonstratorPartNameShort = new TranslationData();
-        [Tooltip("Texture to use in the museum posters for this vehicle")]
+        [Tooltip("Texture to use in the museum posters for this vehicle\n" +
+            "The texture size should be a 512x512px square\n" +
+            "The top 112px will be hidden behind the name box of the poster")]
         public Texture2D? DemonstratorPoster;
         [Tooltip("Livery icon for the demonstrator paint")]
         public Sprite? DemonstratorIcon;

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -70,9 +70,9 @@ namespace CCL.Types
             "Leave at 0 to ignore")]
         public int MaxRepeatedSpawn = 0;
         [Space]
-        [Tooltip("Only affects Passenger Jobs")]
+        [Tooltip("Spawn this livery in regional routes in Passenger Jobs")]
         public bool AllowOnRegionalRoutes = true;
-        [Tooltip("Only affects Passenger Jobs")]
+        [Tooltip("Spawn this livery in express routes in Passenger Jobs")]
         public bool AllowOnExpressRoutes = true;
         [Space]
         [Tooltip("Cost to order replacement parts for this vehicle during a demonstrator quest")]
@@ -85,6 +85,12 @@ namespace CCL.Types
         public Sprite? DemonstratorIcon;
         [Tooltip("Livery icon for the rusty demonstrator paint")]
         public Sprite? DemonstratorRustedIcon;
+        [Tooltip("The prefab for the parts cargo, when loaded on the DM1U")]
+        public GameObject? PartsCargoPrefabDM1U;
+        [Tooltip("The prefab for the parts cargo, when loaded on the Utility Flatbed")]
+        public GameObject? PartsCargoPrefabFlatbed;
+        [Tooltip("The mass of the parts cargo")]
+        public float PartsCargoMass = 10000.0f;
 
         [RenderMethodButtons, SerializeField]
         [MethodButton("CCL.Creator.Wizards.CarPrefabManipulators:AlignBogieColliders", "Align Bogie Colliders")]

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -75,10 +75,16 @@ namespace CCL.Types
         [Tooltip("Only affects Passenger Jobs")]
         public bool AllowOnExpressRoutes = true;
         [Space]
-        [Tooltip("Cost to order replacement parts for this locomotive during a demonstrator quest")]
+        [Tooltip("Cost to order replacement parts for this vehicle during a demonstrator quest")]
         public float DemonstratorPartsOrderCost = 15000.0f;
-        [Tooltip("Cost to install replacement parts for this locomotive during a demonstrator quest")]
+        [Tooltip("Cost to install replacement parts for this vehicle during a demonstrator quest")]
         public float DemonstratorPartsInstallationCost = 10000.0f;
+        [Tooltip("Texture to use in the museum posters for this vehicle")]
+        public Texture2D? DemonstratorPoster;
+        [Tooltip("Livery icon for the demonstrator paint")]
+        public Sprite? DemonstratorIcon;
+        [Tooltip("Livery icon for the rusty demonstrator paint")]
+        public Sprite? DemonstratorRustedIcon;
 
         [RenderMethodButtons, SerializeField]
         [MethodButton("CCL.Creator.Wizards.CarPrefabManipulators:AlignBogieColliders", "Align Bogie Colliders")]

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -79,6 +79,10 @@ namespace CCL.Types
         public float DemonstratorPartsOrderCost = 15000.0f;
         [Tooltip("Cost to install replacement parts for this vehicle during a demonstrator quest"), Min(0)]
         public float DemonstratorPartsInstallationCost = 10000.0f;
+        [Tooltip("The name of the demonstrator parts cargo")]
+        public TranslationData DemonstratorPartName = new TranslationData();
+        [Tooltip("The shortened name of the demonstrator parts cargo")]
+        public TranslationData DemonstratorPartNameShort = new TranslationData();
         [Tooltip("Texture to use in the museum posters for this vehicle")]
         public Texture2D? DemonstratorPoster;
         [Tooltip("Livery icon for the demonstrator paint")]
@@ -93,6 +97,10 @@ namespace CCL.Types
         public GameObject? PartsCargoPrefabFlatbed;
         [Tooltip("The mass of the parts cargo")]
         public float PartsCargoMass = 10000.0f;
+        [SerializeField, HideInInspector]
+        private string? _demoPartNameJson = string.Empty;
+        [SerializeField, HideInInspector]
+        private string? _demoPartNameShortJson = string.Empty;
 
         [RenderMethodButtons, SerializeField]
         [MethodButton("CCL.Creator.Wizards.CarPrefabManipulators:AlignBogieColliders", "Align Bogie Colliders")]
@@ -136,6 +144,8 @@ namespace CCL.Types
             NameTranslationJson = JSONObject.ToJson(NameTranslations.Items);
 
             _spawnGroupJson = JSONObject.ToJson(LocoSpawnGroups);
+            _demoPartNameJson = JSONObject.ToJson(DemonstratorPartName);
+            _demoPartNameShortJson = JSONObject.ToJson(DemonstratorPartNameShort);
         }
 
         public void ForceValidation()
@@ -171,6 +181,8 @@ namespace CCL.Types
             }
 
             LocoSpawnGroups = JSONObject.FromJson(_spawnGroupJson, () => LocoSpawnGroups);
+            DemonstratorPartName = JSONObject.FromJson(_demoPartNameJson, () => TranslationData.Default());
+            DemonstratorPartNameShort = JSONObject.FromJson(_demoPartNameShortJson, () => TranslationData.Default());
         }
     }
 }

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -47,8 +47,8 @@ namespace CCL.Types
         public bool HideBackCoupler = false;
 
         [Header("Trainset - optional")]
-        [Tooltip("This is used to tell if this vehicle is part of a set of vehicles\n" +
-            "Examples are a locomotive and her tender (S282A + S282B)\n" +
+        [Tooltip("This is used to tell if this livery is part of a set of vehicles, " +
+            "such as a locomotive and her tender (S282A + S282B)\n" +
             "Order is important")]
         public string[] TrainsetLiveries = new string[0];
 
@@ -62,16 +62,6 @@ namespace CCL.Types
         public float UnlockPrice = 30000.0f;
         public float SummonPrice = 5000.0f;
 
-        [Header("Demonstrator Quest - optional")]
-        [Tooltip("Cost to order replacement parts for this locomotive during a demonstrator quest.\n" +
-            "Provided for other mods implementing demonstrator features.\n" +
-            "Leave at 0 if not used.")]
-        public float DemonstratorPartsOrderCost = 0f;
-        [Tooltip("Cost to install replacement parts for this locomotive during a demonstrator quest.\n" +
-            "Provided for other mods implementing demonstrator features.\n" +
-            "Leave at 0 if not used.")]
-        public float DemonstratorPartsInstallationCost = 0f;
-
         [Header("Catalog - optional")]
         public CatalogPage? CatalogPage = null;
 
@@ -79,10 +69,16 @@ namespace CCL.Types
         [Tooltip("Used by other mods to limit or enable repetitive spawning\n" +
             "Leave at 0 to ignore")]
         public int MaxRepeatedSpawn = 0;
+        [Space]
         [Tooltip("Only affects Passenger Jobs")]
         public bool AllowOnRegionalRoutes = true;
         [Tooltip("Only affects Passenger Jobs")]
         public bool AllowOnExpressRoutes = true;
+        [Space]
+        [Tooltip("Cost to order replacement parts for this locomotive during a demonstrator quest")]
+        public float DemonstratorPartsOrderCost = 15000.0f;
+        [Tooltip("Cost to install replacement parts for this locomotive during a demonstrator quest")]
+        public float DemonstratorPartsInstallationCost = 10000.0f;
 
         [RenderMethodButtons, SerializeField]
         [MethodButton("CCL.Creator.Wizards.CarPrefabManipulators:AlignBogieColliders", "Align Bogie Colliders")]

--- a/CCL.Types/CustomCarVariant.cs
+++ b/CCL.Types/CustomCarVariant.cs
@@ -75,9 +75,9 @@ namespace CCL.Types
         [Tooltip("Spawn this livery in express routes in Passenger Jobs")]
         public bool AllowOnExpressRoutes = true;
         [Space]
-        [Tooltip("Cost to order replacement parts for this vehicle during a demonstrator quest")]
+        [Tooltip("Cost to order replacement parts for this vehicle during a demonstrator quest"), Min(0)]
         public float DemonstratorPartsOrderCost = 15000.0f;
-        [Tooltip("Cost to install replacement parts for this vehicle during a demonstrator quest")]
+        [Tooltip("Cost to install replacement parts for this vehicle during a demonstrator quest"), Min(0)]
         public float DemonstratorPartsInstallationCost = 10000.0f;
         [Tooltip("Texture to use in the museum posters for this vehicle")]
         public Texture2D? DemonstratorPoster;
@@ -115,6 +115,9 @@ namespace CCL.Types
 
                 if (externalInteractablesPrefab != null) yield return externalInteractablesPrefab;
                 if (explodedExternalInteractablesPrefab != null) yield return explodedExternalInteractablesPrefab;
+
+                if (PartsCargoPrefabDM1U != null) yield return PartsCargoPrefabDM1U;
+                if (PartsCargoPrefabFlatbed != null) yield return PartsCargoPrefabFlatbed;
             }
         }
 

--- a/CCL.Types/ExporterConstants.cs
+++ b/CCL.Types/ExporterConstants.cs
@@ -5,7 +5,7 @@ namespace CCL.Types
     public static class ExporterConstants
     {
         public const string MOD_ID = "DVCustomCarLoader";
-        public static readonly Version ExporterVersion = new Version(3, 1, 8);
+        public static readonly Version ExporterVersion = new Version(3, 1, 9);
         public static readonly Version MinimumCompatibleVersion = new Version(3, 1, 0);
         public const string MINIMUM_DV_BUILD = "build2702";
         public const int BUILD_INT = 2702;

--- a/CCL.Types/MiscEnums.cs
+++ b/CCL.Types/MiscEnums.cs
@@ -51,4 +51,13 @@
         Front,
         Rear
     }
+
+    public enum PartsCargoModel
+    {
+        GenericBox,
+        BoilerS060,
+        WheelsS282,
+        EngineDE6,
+        Custom = 1000
+    }
 }

--- a/CCL.Types/Proxies/ExplosionModelHandlerProxy.cs
+++ b/CCL.Types/Proxies/ExplosionModelHandlerProxy.cs
@@ -1,17 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace CCL.Types.Proxies
 {
     [AddComponentMenu("CCL/Proxies/Explosion Model Handler Proxy")]
-    public class ExplosionModelHandlerProxy : MonoBehaviour, ICustomSerialized
+    public class ExplosionModelHandlerProxy : MonoBehaviour, ICustomSerialized, ISelfValidation
     {
         [Serializable]
         public class MaterialSwapData
         {
             public Material swapMaterial = null!;
             public GameObject[] affectedGameObjects = new GameObject[0];
+
+            public bool AnyNull()
+            {
+                return swapMaterial == null || affectedGameObjects.Any(x => x == null);
+            }
         }
 
         [Serializable]
@@ -19,14 +25,17 @@ namespace CCL.Types.Proxies
         {
             public GameObject gameObjectToReplace = null!;
             public GameObject replacePrefab = null!;
+
+            public bool AnyNull()
+            {
+                return gameObjectToReplace == null || replacePrefab == null;
+            }
         }
 
         [Tooltip("All of these GameObjects will be disabled on explosion")]
         public GameObject[] gameObjectsToDisable = new GameObject[0];
-
         [Tooltip("These will swap 2 GameObjects")]
         public GameObjectSwapData[] gameObjectSwaps = new GameObjectSwapData[0];
-
         [Tooltip("These will replace the material on all renderers of a GameObject")]
         public MaterialSwapData[] materialSwaps = new MaterialSwapData[0];
 
@@ -92,6 +101,26 @@ namespace CCL.Types.Proxies
                     affectedGameObjects = affectedGosTemp[i]
                 };
             }
+        }
+
+        public SelfValidationResult Validate(out string message, out string? highlight)
+        {
+            if (gameObjectsToDisable.Any(x => x == null))
+            {
+                return this.FailForNullEntries(nameof(gameObjectsToDisable), out message, out highlight);
+            }
+
+            if (gameObjectSwaps.Any(x => x == null || x.AnyNull()))
+            {
+                return this.FailForNullEntries(nameof(gameObjectSwaps), out message, out highlight);
+            }
+
+            if (materialSwaps.Any(x => x == null || x.AnyNull()))
+            {
+                return this.FailForNullEntries(nameof(materialSwaps), out message, out highlight);
+            }
+
+            return this.Pass(out message, out highlight);
         }
     }
 }

--- a/repository.json
+++ b/repository.json
@@ -2,6 +2,11 @@
   "Releases": [
     {
       "Id": "DVCustomCarLoader",
+      "Version": "3.1.9",
+      "DownloadUrl": "https://github.com/derail-valley-modding/custom-car-loader/releases/download/v3.1.9/DVCustomCarLoader.zip"
+    },
+    {
+      "Id": "DVCustomCarLoader",
       "Version": "3.1.8",
       "DownloadUrl": "https://github.com/derail-valley-modding/custom-car-loader/releases/download/v3.1.8/DVCustomCarLoader.zip"
     },


### PR DESCRIPTION
Added working cargo amount multipliers.
Added Flywheel custom sim component.
Added fields in the liveries for improved compatibility with the Custom Demonstrators mod.
* These include demo parts cargo prefabs, prices, icons and poster.

Added custom texture support for sightglass generation.
Added catalog validation.
Added custom body shapes to the catalog's diagram.

Improved spawn chances console command. Check the wiki for usage.
* Now shows livery and type chances if they are different.
* All stations mode that lists chances across the entire map.
* All spawns in a single station.

Improved cargo wizard.
Improved ingame error window.
* Will also show an error if Number Manager is detected. This will not prevent either mod from loading.

Improved validation.

Fixed missing reverser step in custom tutorials.
Fixed interaction between tutorials and `Keep Coupled Interior Loaded`.